### PR TITLE
install tinytex

### DIFF
--- a/.github/workflows/pkgdown.yaml
+++ b/.github/workflows/pkgdown.yaml
@@ -58,6 +58,13 @@ jobs:
           repo-token: ${{ github.token }}
 
       - uses: r-lib/actions/setup-pandoc@v2
+      
+      - name: Set up Quarto
+        uses: quarto-dev/quarto-actions/setup@HEAD
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          tinytex: true
 
       - uses: r-lib/actions/setup-r@v2
         with:
@@ -71,12 +78,7 @@ jobs:
           extra-packages: |
             local::.
             r-lib/pkgdown
-            
-      - name: "Install tinytex"
-        run: |
-          quarto install tinytex
-          
-
+       
       # If events is a PR, set subdir to 'preview/pr<pr_number>'
       - name: "[PR] Set documentation subdirectory"
         if: github.event_name == 'pull_request'

--- a/.github/workflows/pkgdown.yaml
+++ b/.github/workflows/pkgdown.yaml
@@ -71,6 +71,11 @@ jobs:
           extra-packages: |
             local::.
             r-lib/pkgdown
+            
+      - name: "Install tinytex"
+        run: |
+          quarto install tinytex
+          
 
       # If events is a PR, set subdir to 'preview/pr<pr_number>'
       - name: "[PR] Set documentation subdirectory"
@@ -102,7 +107,7 @@ jobs:
         run: |
           subdir <- "${{ env.subdir }}"
           pkg <- pkgdown::as_pkgdown(".")
-
+          
           # Deploy pkgdown site to branch
           pkgdown::deploy_to_branch(subdir = if (nzchar(subdir)) subdir, clean = nzchar(subdir))
 


### PR DESCRIPTION
makes sure quarto doesn't fail when some vignettes have pdf-based output options (the pdfs will be hidden in the pkgdown site; can access by going to html versions and changing the url suffix accordingly)