### PR TITLE
Run_mod data input documentation fix

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: serodynamics
 Title: What the Package Does (One Line, Title Case)
-Version: 0.0.0.9034
+Version: 0.0.0.9035
 Authors@R: c(
     person("Peter", "Teunis", , "p.teunis@emory.edu", role = c("aut", "cph"),
            comment = "Author of the method and original code."),

--- a/NEWS.md
+++ b/NEWS.md
@@ -4,6 +4,7 @@
 
 ## New features
 
+* Updating run_mod description specifying data input values ()
 * Replacing old data object with new run_mod output (#102)
 * Adding class assignment to run_mod output (#76)
 * Making prep_priors modifiable (#78)

--- a/NEWS.md
+++ b/NEWS.md
@@ -4,7 +4,7 @@
 
 ## New features
 
-* Updating run_mod description specifying data input values ()
+* Updating run_mod description specifying data input values (#105)
 * Replacing old data object with new run_mod output (#102)
 * Adding class assignment to run_mod output (#76)
 * Making prep_priors modifiable (#78)

--- a/R/Run_Mod.R
+++ b/R/Run_Mod.R
@@ -12,7 +12,8 @@
 #'  - shape = shape parameter
 #'  - alpha = decay rate
 #' @param data A [base::data.frame()] with the following columns. These values
-#' can be clarified as inputs using [serodynamics::as_case_data()]
+#' can be clarified as inputs using [serodynamics::as_case_data()] if not
+#' explicitly labeled as so.
 #'  - id_var = The ID of individuals included
 #'  - biomarker_var = The different antigen isotype combinations that are being
 #'  measured.

--- a/R/Run_Mod.R
+++ b/R/Run_Mod.R
@@ -11,7 +11,13 @@
 #'  - t1 = time to peak
 #'  - shape = shape parameter
 #'  - alpha = decay rate
-#' @param data A [base::data.frame()] with the following columns.
+#' @param data A [base::data.frame()] with the following columns. These values
+#' can be clarified as inputs using [serodynamics::as_case_data()]
+#'  - id_var = The ID of individuals included
+#'  - biomarker_var = The different antigen isotype combinations that are being
+#'  measured.
+#'  - timeindays = The amount of time in days since symptom onset. 
+#'  - value_var = The measured assay value.
 #' @param file_mod The name of the file that contains model structure.
 #' @param nchain An [integer] between 1 and 4 that specifies
 #' the number of MCMC chains to be run per jags model.

--- a/R/Run_Mod.R
+++ b/R/Run_Mod.R
@@ -16,9 +16,9 @@
 #' explicitly labeled as so.
 #'  - id_var = The ID of individuals included
 #'  - biomarker_var = The different antigen isotype combinations that are being
-#'  measured.
-#'  - timeindays = The amount of time in days since symptom onset. 
-#'  - value_var = The measured assay value.
+#'  measured
+#'  - timeindays = The amount of time in days since symptom onset
+#'  - value_var = The measured assay value
 #' @param file_mod The name of the file that contains model structure.
 #' @param nchain An [integer] between 1 and 4 that specifies
 #' the number of MCMC chains to be run per jags model.

--- a/inst/WORDLIST
+++ b/inst/WORDLIST
@@ -1,6 +1,8 @@
+Biomarker
 CMD
 CodeFactor
 Codecov
+Hyperpriors
 JAGs
 Lifecycle
 Postprocess
@@ -9,6 +11,8 @@ Traceplots
 behaviour
 biomarker
 biomarkers
+bmatrix
+cdot
 dobson
 dotplots
 geoms
@@ -16,13 +20,17 @@ ggproto
 hyp
 hyperprior
 hyperpriors
+ij
 iso
 isotype
 isotypes
+mathcal
 mcmc
 nmc
+overfit
 params
 prec
+pred
 rhat
 sd
 seroconversion
@@ -32,5 +40,7 @@ seroresponses
 strat
 stratifications
 tbl
+tibble
+timeindays
 unstratified
 wishdf

--- a/man/run_mod.Rd
+++ b/man/run_mod.Rd
@@ -18,7 +18,15 @@ run_mod(
 )
 }
 \arguments{
-\item{data}{A \code{\link[base:data.frame]{base::data.frame()}} with the following columns.}
+\item{data}{A \code{\link[base:data.frame]{base::data.frame()}} with the following columns. These values
+can be clarified as inputs using \code{\link[=as_case_data]{as_case_data()}}
+\itemize{
+\item id_var = The ID of individuals included
+\item biomarker_var = The different antigen isotype combinations that are being
+measured.
+\item timeindays = The amount of time in days since symptom onset.
+\item value_var = The measured assay value.
+}}
 
 \item{file_mod}{The name of the file that contains model structure.}
 

--- a/man/run_mod.Rd
+++ b/man/run_mod.Rd
@@ -24,9 +24,9 @@ explicitly labeled as so.
 \itemize{
 \item id_var = The ID of individuals included
 \item biomarker_var = The different antigen isotype combinations that are being
-measured.
-\item timeindays = The amount of time in days since symptom onset.
-\item value_var = The measured assay value.
+measured
+\item timeindays = The amount of time in days since symptom onset
+\item value_var = The measured assay value
 }}
 
 \item{file_mod}{The name of the file that contains model structure.}

--- a/man/run_mod.Rd
+++ b/man/run_mod.Rd
@@ -19,7 +19,8 @@ run_mod(
 }
 \arguments{
 \item{data}{A \code{\link[base:data.frame]{base::data.frame()}} with the following columns. These values
-can be clarified as inputs using \code{\link[=as_case_data]{as_case_data()}}
+can be clarified as inputs using \code{\link[=as_case_data]{as_case_data()}} if not
+explicitly labeled as so.
 \itemize{
 \item id_var = The ID of individuals included
 \item biomarker_var = The different antigen isotype combinations that are being


### PR DESCRIPTION
For this pull request I am specifying the documentation for the run_mod data input. Here we are listing the different columns necessary for run_mod, including: id_var, biomarker_var, timeindays, and value_var. I am also including as_case_data as a reference for specifying these variables as attributes. 