### PR TITLE
Auto-yield review requests to d-morrison around Claude runs

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -19,8 +19,6 @@ jobs:
     #   github.event.pull_request.author_association == 'FIRST_TIME_CONTRIBUTOR'
 
     runs-on: ubuntu-latest
-    env:
-      MY_REVIEWER: d-morrison
     permissions:
       contents: read
       pull-requests: write
@@ -33,13 +31,26 @@ jobs:
         with:
           fetch-depth: 1
 
-      - name: Drop my review request while Claude reviews
+      - name: Stash and clear all review requests while Claude reviews
+        id: stash
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
         run: |
-          gh api -X DELETE \
-            "repos/${{ github.repository }}/pulls/${{ github.event.pull_request.number }}/requested_reviewers" \
-            -f "reviewers[]=$MY_REVIEWER" || true
+          REVIEWERS_JSON=$(gh api "repos/${{ github.repository }}/pulls/$PR_NUMBER/requested_reviewers")
+          USERS=$(echo "$REVIEWERS_JSON" | jq -c '[.users[].login]')
+          TEAMS=$(echo "$REVIEWERS_JSON" | jq -c '[.teams[].slug]')
+          echo "users=$USERS" >> "$GITHUB_OUTPUT"
+          echo "teams=$TEAMS" >> "$GITHUB_OUTPUT"
+          echo "Stashed users: $USERS"
+          echo "Stashed teams: $TEAMS"
+          if [ "$USERS" != "[]" ] || [ "$TEAMS" != "[]" ]; then
+            jq -n --argjson users "$USERS" --argjson teams "$TEAMS" \
+              '{reviewers: $users, team_reviewers: $teams}' \
+              | gh api -X DELETE \
+                  "repos/${{ github.repository }}/pulls/$PR_NUMBER/requested_reviewers" \
+                  --input - || true
+          fi
 
       - name: Run Claude Code Review
         id: claude-review
@@ -52,12 +63,22 @@ jobs:
           # See https://github.com/anthropics/claude-code-action/blob/main/docs/usage.md
           # or https://code.claude.com/docs/en/cli-reference for available options
 
-      - name: Re-request my review now that Claude is done
-        if: always() && github.event.pull_request.user.login != env.MY_REVIEWER
+      - name: Restore review requests now that Claude is done
+        if: always() && steps.stash.outcome == 'success'
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          USERS: ${{ steps.stash.outputs.users }}
+          TEAMS: ${{ steps.stash.outputs.teams }}
         run: |
-          gh api -X POST \
-            "repos/${{ github.repository }}/pulls/${{ github.event.pull_request.number }}/requested_reviewers" \
-            -f "reviewers[]=$MY_REVIEWER" || true
-
+          USERS=${USERS:-[]}
+          TEAMS=${TEAMS:-[]}
+          if [ "$USERS" = "[]" ] && [ "$TEAMS" = "[]" ]; then
+            echo "No reviewers were originally requested."
+            exit 0
+          fi
+          jq -n --argjson users "$USERS" --argjson teams "$TEAMS" \
+            '{reviewers: $users, team_reviewers: $teams}' \
+            | gh api -X POST \
+                "repos/${{ github.repository }}/pulls/$PR_NUMBER/requested_reviewers" \
+                --input - || true

--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -19,9 +19,11 @@ jobs:
     #   github.event.pull_request.author_association == 'FIRST_TIME_CONTRIBUTOR'
 
     runs-on: ubuntu-latest
+    env:
+      MY_REVIEWER: d-morrison
     permissions:
       contents: read
-      pull-requests: read
+      pull-requests: write
       issues: read
       id-token: write
 
@@ -30,6 +32,14 @@ jobs:
         uses: actions/checkout@v4
         with:
           fetch-depth: 1
+
+      - name: Drop my review request while Claude reviews
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          gh api -X DELETE \
+            "repos/${{ github.repository }}/pulls/${{ github.event.pull_request.number }}/requested_reviewers" \
+            -f "reviewers[]=$MY_REVIEWER" || true
 
       - name: Run Claude Code Review
         id: claude-review
@@ -41,4 +51,13 @@ jobs:
           prompt: '/code-review:code-review ${{ github.repository }}/pull/${{ github.event.pull_request.number }}'
           # See https://github.com/anthropics/claude-code-action/blob/main/docs/usage.md
           # or https://code.claude.com/docs/en/cli-reference for available options
+
+      - name: Re-request my review now that Claude is done
+        if: always() && github.event.pull_request.user.login != env.MY_REVIEWER
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          gh api -X POST \
+            "repos/${{ github.repository }}/pulls/${{ github.event.pull_request.number }}/requested_reviewers" \
+            -f "reviewers[]=$MY_REVIEWER" || true
 

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -18,8 +18,6 @@ jobs:
       (github.event_name == 'pull_request_review' && contains(github.event.review.body, '@claude')) ||
       (github.event_name == 'issues' && (contains(github.event.issue.body, '@claude') || contains(github.event.issue.title, '@claude')))
     runs-on: ubuntu-latest
-    env:
-      MY_REVIEWER: d-morrison
     permissions:
       contents: read
       pull-requests: write
@@ -48,14 +46,27 @@ jobs:
               ;;
           esac
 
-      - name: Drop my review request while Claude works
+      - name: Stash and clear all review requests while Claude works
+        id: stash
         if: steps.pr.outputs.number != ''
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR_NUMBER: ${{ steps.pr.outputs.number }}
         run: |
-          gh api -X DELETE \
-            "repos/${{ github.repository }}/pulls/${{ steps.pr.outputs.number }}/requested_reviewers" \
-            -f "reviewers[]=$MY_REVIEWER" || true
+          REVIEWERS_JSON=$(gh api "repos/${{ github.repository }}/pulls/$PR_NUMBER/requested_reviewers")
+          USERS=$(echo "$REVIEWERS_JSON" | jq -c '[.users[].login]')
+          TEAMS=$(echo "$REVIEWERS_JSON" | jq -c '[.teams[].slug]')
+          echo "users=$USERS" >> "$GITHUB_OUTPUT"
+          echo "teams=$TEAMS" >> "$GITHUB_OUTPUT"
+          echo "Stashed users: $USERS"
+          echo "Stashed teams: $TEAMS"
+          if [ "$USERS" != "[]" ] || [ "$TEAMS" != "[]" ]; then
+            jq -n --argjson users "$USERS" --argjson teams "$TEAMS" \
+              '{reviewers: $users, team_reviewers: $teams}' \
+              | gh api -X DELETE \
+                  "repos/${{ github.repository }}/pulls/$PR_NUMBER/requested_reviewers" \
+                  --input - || true
+          fi
 
       - name: Run Claude Code
         id: claude
@@ -75,17 +86,26 @@ jobs:
           # or https://code.claude.com/docs/en/cli-reference for available options
           # claude_args: '--allowed-tools Bash(gh pr *)'
 
-      - name: Re-request my review now that Claude is done
-        if: always() && steps.pr.outputs.number != ''
+      - name: Restore review requests now that Claude is done
+        if: always() && steps.stash.outcome == 'success' && steps.pr.outputs.number != ''
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR_NUMBER: ${{ steps.pr.outputs.number }}
+          USERS: ${{ steps.stash.outputs.users }}
+          TEAMS: ${{ steps.stash.outputs.teams }}
         run: |
-          PR_AUTHOR=$(gh api "repos/${{ github.repository }}/pulls/${{ steps.pr.outputs.number }}" --jq .user.login)
-          if [ "$PR_AUTHOR" = "$MY_REVIEWER" ]; then
-            echo "PR author is $MY_REVIEWER; skipping self-review request."
+          if [ -z "$USERS" ] && [ -z "$TEAMS" ]; then
+            echo "Nothing to restore."
             exit 0
           fi
-          gh api -X POST \
-            "repos/${{ github.repository }}/pulls/${{ steps.pr.outputs.number }}/requested_reviewers" \
-            -f "reviewers[]=$MY_REVIEWER" || true
-
+          USERS=${USERS:-[]}
+          TEAMS=${TEAMS:-[]}
+          if [ "$USERS" = "[]" ] && [ "$TEAMS" = "[]" ]; then
+            echo "No reviewers were originally requested."
+            exit 0
+          fi
+          jq -n --argjson users "$USERS" --argjson teams "$TEAMS" \
+            '{reviewers: $users, team_reviewers: $teams}' \
+            | gh api -X POST \
+                "repos/${{ github.repository }}/pulls/$PR_NUMBER/requested_reviewers" \
+                --input - || true

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -18,9 +18,11 @@ jobs:
       (github.event_name == 'pull_request_review' && contains(github.event.review.body, '@claude')) ||
       (github.event_name == 'issues' && (contains(github.event.issue.body, '@claude') || contains(github.event.issue.title, '@claude')))
     runs-on: ubuntu-latest
+    env:
+      MY_REVIEWER: d-morrison
     permissions:
       contents: read
-      pull-requests: read
+      pull-requests: write
       issues: read
       id-token: write
       actions: read # Required for Claude to read CI results on PRs
@@ -29,6 +31,31 @@ jobs:
         uses: actions/checkout@v4
         with:
           fetch-depth: 1
+
+      - name: Resolve PR number (if any)
+        id: pr
+        env:
+          ISSUE_HAS_PR: ${{ github.event.issue.pull_request != null }}
+        run: |
+          case "${{ github.event_name }}" in
+            issue_comment)
+              if [ "$ISSUE_HAS_PR" = "true" ]; then
+                echo "number=${{ github.event.issue.number }}" >> "$GITHUB_OUTPUT"
+              fi
+              ;;
+            pull_request_review_comment|pull_request_review)
+              echo "number=${{ github.event.pull_request.number }}" >> "$GITHUB_OUTPUT"
+              ;;
+          esac
+
+      - name: Drop my review request while Claude works
+        if: steps.pr.outputs.number != ''
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          gh api -X DELETE \
+            "repos/${{ github.repository }}/pulls/${{ steps.pr.outputs.number }}/requested_reviewers" \
+            -f "reviewers[]=$MY_REVIEWER" || true
 
       - name: Run Claude Code
         id: claude
@@ -47,4 +74,18 @@ jobs:
           # See https://github.com/anthropics/claude-code-action/blob/main/docs/usage.md
           # or https://code.claude.com/docs/en/cli-reference for available options
           # claude_args: '--allowed-tools Bash(gh pr *)'
+
+      - name: Re-request my review now that Claude is done
+        if: always() && steps.pr.outputs.number != ''
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          PR_AUTHOR=$(gh api "repos/${{ github.repository }}/pulls/${{ steps.pr.outputs.number }}" --jq .user.login)
+          if [ "$PR_AUTHOR" = "$MY_REVIEWER" ]; then
+            echo "PR author is $MY_REVIEWER; skipping self-review request."
+            exit 0
+          fi
+          gh api -X POST \
+            "repos/${{ github.repository }}/pulls/${{ steps.pr.outputs.number }}/requested_reviewers" \
+            -f "reviewers[]=$MY_REVIEWER" || true
 


### PR DESCRIPTION
## Summary
- Before each Claude run on a PR, snapshot the current set of requested user and team reviewers, then clear them so review notifications don't pile up while Claude works.
- When Claude finishes (success or failure), restore exactly that set of reviewers — same users, same teams.
- Bumps `pull-requests` permission from `read` to `write` so the bot can manage reviewer requests.

## How it works
1. `Stash and clear all review requests` step calls `GET .../requested_reviewers`, writes the user logins and team slugs to step outputs, then `DELETE`s them in one call.
2. Claude runs.
3. `Restore review requests` step runs with `if: always()` and re-`POST`s the stashed users + teams.

If no reviewers were requested at start, the restore step is a no-op. All reviewer-mutation API calls are wrapped in `|| true` so reviewer-state hiccups can't fail the workflow.

## Test plan
- [ ] Trigger `@claude` on a PR that has requested reviewers and confirm they disappear at start and reappear at end (including team reviewers).
- [ ] Trigger `@claude` on a PR with no requested reviewers and confirm the workflow runs cleanly.
- [ ] Open a fresh PR with reviewers preset and confirm the auto-review workflow yields and restores the same set.
- [ ] Confirm `@claude` on a non-PR issue runs without touching reviewers.

🤖 Generated with [Claude Code](https://claude.com/claude-code)