### PR TITLE
ci: always post Claude code review summary

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -60,6 +60,9 @@ jobs:
           plugin_marketplaces: 'https://github.com/anthropics/claude-code.git'
           plugins: 'code-review@claude-code-plugins'
           prompt: '/code-review:code-review ${{ github.repository }}/pull/${{ github.event.pull_request.number }}'
+          # Always post a summary comment so the run is never silent — even when
+          # Claude has no inline comments to make.
+          display_report: 'true'
           # See https://github.com/anthropics/claude-code-action/blob/main/docs/usage.md
           # or https://code.claude.com/docs/en/cli-reference for available options
 


### PR DESCRIPTION
## Summary

- On PR #207, the Claude Code Review workflow ran successfully but posted no comment. The action logged `"permission_denials_count": 21`, `"is_error": false`, and `No buffered inline comments` — Claude finished, but never queued an inline comment, and the action's defaults (`display_report: false`, `track_progress: false`, `use_sticky_comment: false`) meant no summary was posted either.
- This sets `display_report: 'true'` on the `anthropics/claude-code-action@v1` step so the run is never silent. Even when Claude has nothing inline-worthy to flag, the action will post a summary comment confirming it ran.

## Test plan

- [ ] Merge and observe the next PR opened against `main` — confirm a Claude summary comment appears on the PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)