### PR TITLE
ci: post Claude review summary to PR via sticky comment

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -22,7 +22,7 @@ jobs:
     permissions:
       contents: read
       pull-requests: write
-      issues: read
+      issues: write
       id-token: write
 
     steps:
@@ -52,6 +52,26 @@ jobs:
                   --input - || true
           fi
 
+      - name: Delete prior Claude sticky comment so the new one lands at the bottom
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          # Mirrors how anthropics/claude-code-action locates its sticky comment to update.
+          # See create-initial.ts in:
+          # https://github.com/anthropics/claude-code-action/tree/main/src/github/operations/comments
+          CLAUDE_APP_BOT_ID: '209825114'
+        run: |
+          CID=$(gh api --paginate \
+            "repos/${{ github.repository }}/issues/$PR_NUMBER/comments" \
+            --jq ".[] | select(.user.id == $CLAUDE_APP_BOT_ID or (.user.type == \"Bot\" and (.user.login | ascii_downcase | contains(\"claude\")))) | .id" \
+            | head -n 1)
+          if [ -n "$CID" ]; then
+            echo "Deleting prior Claude comment $CID so the new sticky lands at the bottom."
+            gh api -X DELETE "repos/${{ github.repository }}/issues/comments/$CID" || true
+          else
+            echo "No prior Claude comment found; action will create a fresh sticky."
+          fi
+
       - name: Run Claude Code Review
         id: claude-review
         uses: anthropics/claude-code-action@v1
@@ -63,6 +83,9 @@ jobs:
           # Post a single sticky comment on the PR with the review summary,
           # so the run is never silent even when Claude has no inline comments.
           # (display_report only writes to the Actions step summary page, not the PR.)
+          # The previous sticky is deleted in the step above so this comment
+          # always lands at the bottom of the conversation rather than getting
+          # buried in place.
           use_sticky_comment: 'true'
           display_report: 'true'
           # See https://github.com/anthropics/claude-code-action/blob/main/docs/usage.md

--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -60,8 +60,10 @@ jobs:
           plugin_marketplaces: 'https://github.com/anthropics/claude-code.git'
           plugins: 'code-review@claude-code-plugins'
           prompt: '/code-review:code-review ${{ github.repository }}/pull/${{ github.event.pull_request.number }}'
-          # Always post a summary comment so the run is never silent — even when
-          # Claude has no inline comments to make.
+          # Post a single sticky comment on the PR with the review summary,
+          # so the run is never silent even when Claude has no inline comments.
+          # (display_report only writes to the Actions step summary page, not the PR.)
+          use_sticky_comment: 'true'
           display_report: 'true'
           # See https://github.com/anthropics/claude-code-action/blob/main/docs/usage.md
           # or https://code.claude.com/docs/en/cli-reference for available options


### PR DESCRIPTION
## Summary

- Follow-up to #211. That PR set `display_report: true`, but per the [`anthropics/claude-code-action` action.yml](https://github.com/anthropics/claude-code-action/blob/main/action.yml), `display_report` only writes the report to the **GitHub Actions step summary page** — it does not post on the PR.
- Verified on PR #207 [run 25901218101](https://github.com/UCD-SERG/serodynamics/actions/runs/25901218101): log showed `Successfully formatted Claude Code report` but no PR comment, confirming `display_report` alone is insufficient.
- This PR adds `use_sticky_comment: 'true'` so the action posts (and on subsequent runs, updates) a single sticky comment on the PR with the review summary, ensuring the workflow is never silent.

## Why we also delete the prior sticky before each run

The action's sticky logic finds the **first** existing Claude bot comment on the PR and updates it in place ([source](https://github.com/anthropics/claude-code-action/blob/main/src/github/operations/comments/create-initial.ts)). That means on repeat runs the comment stays at its original chronological position and can get buried as the discussion grows.

Before invoking the action we delete that prior Claude bot comment (matching the same id/type+login criteria the action uses). The action then finds no existing match and creates a fresh comment, which lands at the bottom of the conversation.

Also bumped `issues` permission from `read` to `write` so the workflow can delete comments.

## Test plan

- [ ] Merge and open a PR — confirm a `claude[bot]` sticky comment appears on the PR with the review summary (including when Claude has no inline comments to make).
- [ ] Push a follow-up commit to the same PR — confirm the previous sticky comment is removed and a new one is posted at the bottom of the conversation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)