### PR TITLE
ci: force tag mode so Claude review always posts a PR comment

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -80,13 +80,23 @@ jobs:
           plugin_marketplaces: 'https://github.com/anthropics/claude-code.git'
           plugins: 'code-review@claude-code-plugins'
           prompt: '/code-review:code-review ${{ github.repository }}/pull/${{ github.event.pull_request.number }}'
-          # Post a single sticky comment on the PR with the review summary,
-          # so the run is never silent even when Claude has no inline comments.
-          # (display_report only writes to the Actions step summary page, not the PR.)
-          # The previous sticky is deleted in the step above so this comment
-          # always lands at the bottom of the conversation rather than getting
-          # buried in place.
+          # Force tag mode (anthropics/claude-code-action src/modes/detector.ts).
+          # In the default agent mode for pull_request events, the action never
+          # posts any non-inline PR comment by itself (src/modes/agent/index.ts:
+          # "No tracking comment in agent mode", commentId: undefined). The
+          # code-review plugin will only post a top-level comment if it finds
+          # issues scoring >= 80, so silent runs are common on small/mechanical
+          # PRs. track_progress forces tag mode, which creates a tracking
+          # comment up front via createInitialComment() and updates it at the
+          # end — guaranteeing a PR comment regardless of plugin output.
+          track_progress: 'true'
+          # Bundle the tracking comment into a single sticky per PR rather than
+          # a new comment each run. (Only consulted in tag mode.) The previous
+          # sticky is deleted in the step above so the new one always lands at
+          # the bottom of the conversation rather than getting buried in place.
           use_sticky_comment: 'true'
+          # Also archive the formatted report to the Actions step summary page
+          # (does not affect PR comments).
           display_report: 'true'
           # See https://github.com/anthropics/claude-code-action/blob/main/docs/usage.md
           # or https://code.claude.com/docs/en/cli-reference for available options


### PR DESCRIPTION
## Summary

Replaces the partial fixes in #211 and #212. After tracing through `anthropics/claude-code-action`'s source, both prior fixes set flags that have no effect in **agent mode** (which is what `pull_request` events auto-detect).

**Root cause** (traced through source):

- `pull_request` events default to **agent mode** ([`src/modes/detector.ts`](https://github.com/anthropics/claude-code-action/blob/main/src/modes/detector.ts)).
- Agent mode explicitly creates **no tracking comment**: see [`src/modes/agent/index.ts`](https://github.com/anthropics/claude-code-action/blob/main/src/modes/agent/index.ts) — comment ``// No tracking comment in agent mode``, returns `commentId: undefined`.
- `use_sticky_comment` is only consulted inside `createInitialComment()`, which is called by **tag mode** only ([`src/modes/tag/index.ts`](https://github.com/anthropics/claude-code-action/blob/main/src/modes/tag/index.ts)) — so it has zero effect in agent mode.
- `display_report` writes the formatted report to `GITHUB_STEP_SUMMARY` (the Actions step summary page), **never** to a PR comment ([`src/entrypoints/run.ts`](https://github.com/anthropics/claude-code-action/blob/main/src/entrypoints/run.ts)).
- The `code-review` plugin only posts a top-level PR comment via ``gh pr comment`` when it finds issues scoring **>= 80**. On small/mechanical PRs (e.g. PR #207's CRAN-prep diff) Claude finds nothing scoring high enough and the plugin exits silently.

**The fix**: set `track_progress: 'true'`, which forces tag mode. Tag mode calls `createInitialComment()` at the start of the run, posting a tracking comment that gets updated with the final result — regardless of whether the plugin posts anything. With `use_sticky_comment: 'true'` kept, this becomes a single sticky per PR rather than one comment per run.

## Verification trail

- PR #207 [run 25901924003](https://github.com/UCD-SERG/serodynamics/actions/runs/25901924003) (after both prior fixes merged): action succeeded with `is_error: false`, 27 turns, 0 permission denials. Log showed `Auto-detected mode: agent for event: pull_request`, `Successfully formatted Claude Code report`, `No buffered inline comments`. No PR comment appeared — proving neither `use_sticky_comment` nor `display_report` are sufficient in agent mode.

## Test plan

- [ ] Merge and open/sync a PR — confirm a `claude[bot]` tracking comment appears on the PR immediately when the workflow starts, and gets updated with the final result when Claude finishes (even when there are no inline findings).

🤖 Generated with [Claude Code](https://claude.com/claude-code)