### PR TITLE
Harden Claude code-review workflow against races and silent failures

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -10,6 +10,15 @@ on:
     #   - "src/**/*.js"
     #   - "src/**/*.jsx"
 
+# Serialize runs per PR. The stash/restore reviewer dance below assumes
+# only one run is mutating the PR's reviewer list at a time; without
+# this, an overlapping second run reads an already-cleared list, stashes
+# [], and on restore wipes the original reviewers permanently. Cancel
+# the in-flight run on a new push so the freshest diff wins.
+concurrency:
+  group: claude-review-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
 jobs:
   claude-review:
     # Optional: Filter by PR author
@@ -31,13 +40,20 @@ jobs:
         with:
           fetch-depth: 1
 
+      # The reviewer stash/restore is a serialization signal: we clear the
+      # human reviewers before Claude runs so they aren't notified mid-run,
+      # then re-add them when Claude finishes so the re-add fires a fresh
+      # GitHub notification — letting the human see Claude's review before
+      # they start their own. The restore is load-bearing for that signal,
+      # so it must NOT silently swallow errors (see restore step below).
       - name: Stash and clear all review requests while Claude reviews
         id: stash
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REPO: ${{ github.repository }}
           PR_NUMBER: ${{ github.event.pull_request.number }}
         run: |
-          REVIEWERS_JSON=$(gh api "repos/${{ github.repository }}/pulls/$PR_NUMBER/requested_reviewers")
+          REVIEWERS_JSON=$(gh api "repos/$REPO/pulls/$PR_NUMBER/requested_reviewers")
           USERS=$(echo "$REVIEWERS_JSON" | jq -c '[.users[].login]')
           TEAMS=$(echo "$REVIEWERS_JSON" | jq -c '[.teams[].slug]')
           echo "users=$USERS" >> "$GITHUB_OUTPUT"
@@ -48,29 +64,30 @@ jobs:
             jq -n --argjson users "$USERS" --argjson teams "$TEAMS" \
               '{reviewers: $users, team_reviewers: $teams}' \
               | gh api -X DELETE \
-                  "repos/${{ github.repository }}/pulls/$PR_NUMBER/requested_reviewers" \
+                  "repos/$REPO/pulls/$PR_NUMBER/requested_reviewers" \
                   --input - || true
           fi
 
-      - name: Delete prior Claude sticky comment so the new one lands at the bottom
+      - name: Delete prior Claude sticky comments so the new one lands at the bottom
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REPO: ${{ github.repository }}
           PR_NUMBER: ${{ github.event.pull_request.number }}
           # Mirrors how anthropics/claude-code-action locates its sticky comment to update.
           # See create-initial.ts in:
           # https://github.com/anthropics/claude-code-action/tree/main/src/github/operations/comments
           CLAUDE_APP_BOT_ID: '209825114'
         run: |
-          CID=$(gh api --paginate \
-            "repos/${{ github.repository }}/issues/$PR_NUMBER/comments" \
+          # Delete every Claude-authored top-level comment, not just the most
+          # recent one — PRs predating use_sticky_comment may have multiple.
+          gh api --paginate \
+            "repos/$REPO/issues/$PR_NUMBER/comments" \
             --jq ".[] | select(.user.id == $CLAUDE_APP_BOT_ID or (.user.type == \"Bot\" and (.user.login | ascii_downcase | contains(\"claude\")))) | .id" \
-            | head -n 1)
-          if [ -n "$CID" ]; then
-            echo "Deleting prior Claude comment $CID so the new sticky lands at the bottom."
-            gh api -X DELETE "repos/${{ github.repository }}/issues/comments/$CID" || true
-          else
-            echo "No prior Claude comment found; action will create a fresh sticky."
-          fi
+            | while read -r CID; do
+                [ -z "$CID" ] && continue
+                echo "Deleting prior Claude comment $CID."
+                gh api -X DELETE "repos/$REPO/issues/comments/$CID" || true
+              done
 
       - name: Run Claude Code Review
         id: claude-review
@@ -105,18 +122,21 @@ jobs:
         if: always() && steps.stash.outcome == 'success'
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REPO: ${{ github.repository }}
           PR_NUMBER: ${{ github.event.pull_request.number }}
           USERS: ${{ steps.stash.outputs.users }}
           TEAMS: ${{ steps.stash.outputs.teams }}
         run: |
-          USERS=${USERS:-[]}
-          TEAMS=${TEAMS:-[]}
           if [ "$USERS" = "[]" ] && [ "$TEAMS" = "[]" ]; then
             echo "No reviewers were originally requested."
             exit 0
           fi
+          # Do NOT add `|| true` here. A failed restore means the human
+          # reviewer was silently dropped from the PR and never gets the
+          # post-Claude notification — fail loudly so it can be re-added
+          # manually instead of vanishing.
           jq -n --argjson users "$USERS" --argjson teams "$TEAMS" \
             '{reviewers: $users, team_reviewers: $teams}' \
             | gh api -X POST \
-                "repos/${{ github.repository }}/pulls/$PR_NUMBER/requested_reviewers" \
-                --input - || true
+                "repos/$REPO/pulls/$PR_NUMBER/requested_reviewers" \
+                --input -

--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -61,6 +61,10 @@ jobs:
           echo "Stashed users: $USERS"
           echo "Stashed teams: $TEAMS"
           if [ "$USERS" != "[]" ] || [ "$TEAMS" != "[]" ]; then
+            # `|| true` is intentional and asymmetric with the restore step:
+            # a failed stash leaves reviewers in place, which only causes a
+            # mid-run notification (recoverable). A failed restore would
+            # silently drop them entirely (not recoverable) — see that step.
             jq -n --argjson users "$USERS" --argjson teams "$TEAMS" \
               '{reviewers: $users, team_reviewers: $teams}' \
               | gh api -X DELETE \
@@ -78,6 +82,10 @@ jobs:
           # https://github.com/anthropics/claude-code-action/tree/main/src/github/operations/comments
           CLAUDE_APP_BOT_ID: '209825114'
         run: |
+          # pipefail so a failure in `gh api --paginate` isn't masked by the
+          # while loop's exit-0 on empty input (the default bash pipeline
+          # exit status is the last command's).
+          set -o pipefail
           # Delete every Claude-authored top-level comment, not just the most
           # recent one — PRs predating use_sticky_comment may have multiple.
           gh api --paginate \

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: serodynamics
 Title: What the Package Does (One Line, Title Case)
-Version: 0.0.0.9050
+Version: 0.0.0.9051
 Authors@R: c(
     person("Peter", "Teunis", , "p.teunis@emory.edu", role = c("aut", "cph"),
            comment = "Author of the method and original code."),

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,9 @@
 # serodynamics (development version)
 
+* Hardened the Claude code-review workflow against races and silent failures:
+  serialized concurrent runs per PR, made reviewer restore fail loudly instead
+  of silently dropping reviewers, and cleaned up all stale Claude top-level
+  comments per run (#216).
 * Expanded `.github/copilot-instructions.md` with additional guidance on evidence-based claims, Quarto markdown/cross-reference conventions, R style practices, and phrase-level line-break formatting for source text.
 * Fixed `dplyr::as_tibble()` references to `tibble::as_tibble()` in `post_summ()` and `run_mod()`, since `as_tibble()` is exported from the `tibble` package, not `dplyr`.
 * Added R 4.5+ snapshot variants to handle the changed attribute ordering in


### PR DESCRIPTION
## Summary

Backports review feedback from [d-morrison/rme#739](https://github.com/d-morrison/rme/pull/739), where Claude reviewed a parallel port of this same workflow. The same issues exist here.

- **Add a `concurrency:` group** so two overlapping PR runs can't race the stash/restore and silently strip reviewers from the PR. `cancel-in-progress: true` so the freshest diff wins.
- **Drop `|| true` on the restore POST** — a failed restore means the human reviewer was silently dropped and never gets the post-Claude notification, defeating the serialization signal. Fail loudly so it can be re-added manually instead of vanishing.
- **Document the intent of the stash/restore inline** — it's a serialization signal (clear reviewers so they don't get notified mid-run; restore so the re-add fires a fresh notification once Claude is done), not a noop.
- **Pass `${{ github.repository }}` via `REPO` env** rather than inlining the GitHub expression into shell scripts in three places.
- **Replace `head -n 1` with a `while read` loop** when deleting prior Claude top-level comments — PRs predating `use_sticky_comment` may have multiple stale comments, and the prior code only cleaned one per run.
- **Remove dead `USERS=${USERS:-[]}` defaults** — the stash step always writes valid JSON to `GITHUB_OUTPUT`, so the fallback was unreachable.

## Test plan

- [ ] Push two commits in quick succession to a draft PR; confirm the second run cancels the first (`concurrency`) and reviewers end up correctly restored at the end.
- [ ] On a PR with a human reviewer requested, confirm the reviewer is removed during the run and re-added afterward (notification fires).
- [ ] Force a restore failure (e.g. revoke the token mid-run) and confirm the workflow surfaces the failure rather than silently swallowing it.
- [ ] On a PR with multiple pre-existing Claude comments, confirm all are cleaned up in one run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)