### PR TITLE
ci: stop deleting prior Claude review comments

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -72,31 +72,6 @@ jobs:
                   --input - || true
           fi
 
-      - name: Delete prior Claude sticky comments so the new one lands at the bottom
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          REPO: ${{ github.repository }}
-          PR_NUMBER: ${{ github.event.pull_request.number }}
-          # Mirrors how anthropics/claude-code-action locates its sticky comment to update.
-          # See create-initial.ts in:
-          # https://github.com/anthropics/claude-code-action/tree/main/src/github/operations/comments
-          CLAUDE_APP_BOT_ID: '209825114'
-        run: |
-          # pipefail so a failure in `gh api --paginate` isn't masked by the
-          # while loop's exit-0 on empty input (the default bash pipeline
-          # exit status is the last command's).
-          set -o pipefail
-          # Delete every Claude-authored top-level comment, not just the most
-          # recent one — PRs predating use_sticky_comment may have multiple.
-          gh api --paginate \
-            "repos/$REPO/issues/$PR_NUMBER/comments" \
-            --jq ".[] | select(.user.id == $CLAUDE_APP_BOT_ID or (.user.type == \"Bot\" and (.user.login | ascii_downcase | contains(\"claude\")))) | .id" \
-            | while read -r CID; do
-                [ -z "$CID" ] && continue
-                echo "Deleting prior Claude comment $CID."
-                gh api -X DELETE "repos/$REPO/issues/comments/$CID" || true
-              done
-
       - name: Run Claude Code Review
         id: claude-review
         uses: anthropics/claude-code-action@v1
@@ -116,9 +91,10 @@ jobs:
           # end — guaranteeing a PR comment regardless of plugin output.
           track_progress: 'true'
           # Bundle the tracking comment into a single sticky per PR rather than
-          # a new comment each run. (Only consulted in tag mode.) The previous
-          # sticky is deleted in the step above so the new one always lands at
-          # the bottom of the conversation rather than getting buried in place.
+          # a new comment each run. (Only consulted in tag mode.) Each new run
+          # updates the same comment in place — the latest review is always
+          # visible, and prior reviews from `@claude review` invocations (which
+          # post as separate non-sticky comments) are left untouched.
           use_sticky_comment: 'true'
           # Also archive the formatted report to the Actions step summary page
           # (does not affect PR comments).

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: serodynamics
 Title: What the Package Does (One Line, Title Case)
-Version: 0.0.0.9051
+Version: 0.0.0.9052
 Authors@R: c(
     person("Peter", "Teunis", , "p.teunis@emory.edu", role = c("aut", "cph"),
            comment = "Author of the method and original code."),

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,9 @@
 # serodynamics (development version)
 
+* Stopped deleting prior Claude review comments at the start of each
+  `Claude Code Review` run, so reviews posted by `@claude review` invocations
+  are preserved across subsequent pushes instead of being wiped when the
+  review step fails its bot-actor gate (#217).
 * Hardened the Claude code-review workflow against races and silent failures:
   serialized concurrent runs per PR, made reviewer restore fail loudly instead
   of silently dropping reviewers, and cleaned up all stale Claude top-level


### PR DESCRIPTION
## Summary
- Removes the `Delete prior Claude sticky comments so the new one lands at the bottom` step from `.github/workflows/claude-code-review.yml`.
- That step ran first and wiped **every** Claude-authored top-level PR comment (matching `claude[bot]` by ID **or** any bot whose login contains "claude") before the review step ran. When the review step then failed — e.g. `Workflow initiated by non-human actor: claude (type: Bot)` after a Claude-pushed fix commit — the prior review was destroyed with no replacement.
- Concrete example: `@claude review` comment [#4480734783 on PR #207](https://github.com/UCD-SERG/serodynamics/pull/207#issuecomment-4480734783) (2026-05-18T18:32:52Z) triggered run [26052743776](https://github.com/UCD-SERG/serodynamics/actions/runs/26052743776), which posted a CRAN-readiness review as comment `4480737380`. A `synchronize` event 17 min later triggered the deletion step in run [26053637375](https://github.com/UCD-SERG/serodynamics/actions/runs/26053637375), which deleted that review (and three other Claude comments) at 18:57:08–11Z, then failed to post a fresh review due to the bot-actor gate. Net result on PR #207: zero surviving Claude review comments out of multiple invocations.

## Behavior after this change
- `@claude review` invocations via `claude.yml` (`use_sticky_comment: false`): each posts a new comment, **never deleted**. Explicit review history accumulates.
- Auto-trigger on `pull_request` via `claude-code-review.yml` (`use_sticky_comment: true`): the action's own sticky-comment logic continues to collapse repeated auto-runs onto one in-place comment, so the noise floor doesn't grow with push count.
- A future review-step failure no longer destroys the previous review.

## Test plan
- [ ] After merge, `@claude review` on an open PR and confirm the resulting comment survives the next push to that PR.
- [ ] Push a commit to a PR and confirm `Claude Code Review` updates its sticky in place rather than creating a duplicate.
- [ ] Confirm no `comment_deleted` events from `github-actions[bot]` appear on a PR's timeline after a `Claude Code Review` run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)