### PR TITLE
ci: let @claude run R and file follow-up issues

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -21,7 +21,7 @@ jobs:
     permissions:
       contents: read
       pull-requests: write
-      issues: read
+      issues: write # so Claude can open follow-up issues for deferred work
       id-token: write
       actions: read # Required for Claude to read CI results on PRs
     steps:
@@ -29,6 +29,28 @@ jobs:
         uses: actions/checkout@v4
         with:
           fetch-depth: 1
+
+      # R toolchain so Claude can run common package-maintenance commands
+      # (e.g. devtools::document(), styler::style_pkg(), pkgdown builds).
+      # Adds ~1–3 min when the dependency cache is warm; the first run after
+      # a lockfile change is slower. JAGS is required because `runjags` is in
+      # Imports and load-all/document needs the package to be loadable.
+      - name: Install JAGS (Ubuntu)
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y jags
+
+      - uses: r-lib/actions/setup-r@v2
+        with:
+          use-public-rspm: true
+
+      - uses: r-lib/actions/setup-r-dependencies@v2
+        with:
+          extra-packages: |
+            any::devtools
+            any::roxygen2
+            any::rjags
+          needs: check
 
       - name: Resolve PR number (if any)
         id: pr
@@ -86,10 +108,12 @@ jobs:
           # Optional: Give a custom prompt to Claude. If this is not specified, Claude will perform the instructions specified in the comment that tagged it.
           # prompt: 'Update the pull request description to include a summary of changes.'
 
-          # Optional: Add claude_args to customize behavior and configuration
-          # See https://github.com/anthropics/claude-code-action/blob/main/docs/usage.md
-          # or https://code.claude.com/docs/en/cli-reference for available options
-          # claude_args: '--allowed-tools Bash(gh pr *)'
+          # Extend the Bash allowlist so Claude can:
+          #   * run package-maintenance R commands (devtools::document(),
+          #     styler::style_pkg(), R CMD ...) — toolchain is installed above;
+          #   * file follow-up issues for work deferred out of the current PR
+          #     (gh issue create / comment / edit / view / list).
+          claude_args: '--allowed-tools "Bash(Rscript:*)" "Bash(R:*)" "Bash(R CMD:*)" "Bash(gh issue:*)"'
 
       - name: Re-assign reviewers after Claude finishes
         if: always() && steps.stash.outcome == 'success' && steps.pr.outputs.number != ''

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -31,14 +31,30 @@ jobs:
           fetch-depth: 1
 
       # R toolchain so Claude can run common package-maintenance commands
-      # (e.g. devtools::document(), styler::style_pkg(), pkgdown builds).
+      # (e.g. devtools::document(), styler::style_pkg(), pkgdown builds,
+      # spelling::spell_check_package(), lintr, R CMD check).
       # Adds ~1–3 min when the dependency cache is warm; the first run after
       # a lockfile change is slower. JAGS is required because `runjags` is in
       # Imports and load-all/document needs the package to be loadable.
-      - name: Install JAGS (Ubuntu)
+      # System libs mirror copilot-setup-steps.yml so packages that source-
+      # build (textshaping, ragg, curl, xml2, ...) don't fail unpredictably.
+      - name: Install system dependencies (Ubuntu)
         run: |
           sudo apt-get update
-          sudo apt-get install -y jags
+          sudo apt-get install -y \
+            jags \
+            libcurl4-openssl-dev \
+            libssl-dev \
+            libxml2-dev \
+            libfontconfig1-dev \
+            libharfbuzz-dev \
+            libfribidi-dev \
+            libfreetype6-dev \
+            libpng-dev \
+            libtiff5-dev \
+            libjpeg-dev
+
+      - uses: r-lib/actions/setup-pandoc@v2
 
       - uses: r-lib/actions/setup-r@v2
         with:
@@ -50,6 +66,10 @@ jobs:
             any::devtools
             any::roxygen2
             any::rjags
+            any::rmarkdown
+            any::lintr
+            any::spelling
+            any::rcmdcheck
           needs: check
 
       - name: Resolve PR number (if any)

--- a/.github/workflows/copilot-setup-steps.yml
+++ b/.github/workflows/copilot-setup-steps.yml
@@ -102,7 +102,7 @@ jobs:
           withr::local_options(warn = 2)
           library(rjags)
           library(runjags)
-          runjags::findJAGS()
+          runjags::findjags()
           runjags::testjags()
         shell: Rscript {0}
       
@@ -119,7 +119,7 @@ jobs:
           Rscript -e 'cat("runjags version:", as.character(packageVersion("runjags")), "\n")'
           echo ""
           echo "JAGS location (from runjags):"
-          Rscript -e 'print(runjags::findJAGS())'
+          Rscript -e 'print(runjags::findjags())'
           echo ""
           echo "Running JAGS test:"
           Rscript -e 'runjags::testjags()'

--- a/.github/workflows/test-coverage.yaml
+++ b/.github/workflows/test-coverage.yaml
@@ -57,7 +57,7 @@ jobs:
            withr::local_options(warn = 2)
            library(rjags)
            library(runjags)
-           runjags::findJAGS()
+           runjags::findjags()
            runjags::testjags()
         shell: Rscript {0}
       

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: serodynamics
 Title: What the Package Does (One Line, Title Case)
-Version: 0.0.0.9053
+Version: 0.0.0.9054
 Authors@R: c(
     person("Peter", "Teunis", , "p.teunis@emory.edu", role = c("aut", "cph"),
            comment = "Author of the method and original code."),

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,13 @@
 # serodynamics (development version)
 
+* Expanded what the `Claude Code` (`@claude`) workflow can do:
+  - Install the R toolchain (R, JAGS, package dependencies, `devtools`,
+    `roxygen2`) and allow `Rscript`, `R`, and `R CMD` invocations, so
+    requests that need package-maintenance commands (e.g.
+    `devtools::document()`) succeed instead of being patched by hand.
+  - Grant `issues: write` and allow `gh issue` invocations so Claude
+    can file follow-up issues for work deferred out of the current PR
+    instead of burying it in a comment.
 * Re-assign reviewers to a PR's human assignees (filtered via
   `type == "User"`) when Claude pushes commits during a `@claude` or
   `Claude Code Review` run; if Claude makes no commits, the original

--- a/NEWS.md
+++ b/NEWS.md
@@ -8,6 +8,9 @@
   - Grant `issues: write` and allow `gh issue` invocations so Claude
     can file follow-up issues for work deferred out of the current PR
     instead of burying it in a comment.
+* Standardized `runjags::findjags()` casing across `test-coverage.yaml`
+  and `copilot-setup-steps.yml` to match the `R-CMD-check.yaml` form
+  arriving with the 0.1.0 release (#207 advisory).
 * Re-assign reviewers to a PR's human assignees (filtered via
   `type == "User"`) when Claude pushes commits during a `@claude` or
   `Claude Code Review` run; if Claude makes no commits, the original

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,10 +1,13 @@
 # serodynamics (development version)
 
 * Expanded what the `Claude Code` (`@claude`) workflow can do:
-  - Install the R toolchain (R, JAGS, package dependencies, `devtools`,
-    `roxygen2`) and allow `Rscript`, `R`, and `R CMD` invocations, so
-    requests that need package-maintenance commands (e.g.
-    `devtools::document()`) succeed instead of being patched by hand.
+  - Install the full R toolchain (R, JAGS, pandoc, the apt system libs
+    mirrored from `copilot-setup-steps.yml`, plus `devtools`, `roxygen2`,
+    `rmarkdown`, `lintr`, `spelling`, `rcmdcheck`) and allow `Rscript`,
+    `R`, and `R CMD` invocations, so requests that need package-
+    maintenance commands (`devtools::document()`,
+    `spelling::spell_check_package()`, `R CMD check`, vignette rebuilds)
+    succeed instead of being patched by hand.
   - Grant `issues: write` and allow `gh issue` invocations so Claude
     can file follow-up issues for work deferred out of the current PR
     instead of burying it in a comment.

--- a/inst/WORDLIST
+++ b/inst/WORDLIST
@@ -39,12 +39,14 @@ iso
 isotype
 isotypes
 libm
+libs
 linux
 mcmc
 mitre
 newperson
 nmc
 onwards
+pandoc
 params
 pkgdown
 prec

--- a/inst/WORDLIST
+++ b/inst/WORDLIST
@@ -17,6 +17,7 @@ SHA
 TSI
 Vectorization
 Wasserstein
+allowlist
 assignees
 behaviour
 biomarker
@@ -56,6 +57,7 @@ strat
 stratifications
 tbl
 testthat
+toolchain
 unstratified
 vh
 wishdf


### PR DESCRIPTION
## Summary
Two capabilities for the `@claude` (`Claude Code` workflow) so it can do work that previously had to be hand-patched or trailed in PR comments.

### R toolchain
- Install JAGS (apt-get) → `r-lib/actions/setup-r@v2` → `setup-r-dependencies@v2` with `any::devtools, any::roxygen2, any::rjags`.
- Extend `claude_args --allowed-tools` with `Bash(Rscript:*)`, `Bash(R:*)`, `Bash(R CMD:*)`.

Motivation: `@claude` requests like "rerun `devtools::document()`" on PR #207 failed because the runner had no R toolchain and the Bash allowlist was git-only. Claude resorted to editing `man/*.Rd` by hand and the maintainer had to verify manually. See [this thread](https://github.com/UCD-SERG/serodynamics/pull/207#issuecomment-4483047121).

Cost: ~1–3 min of extra setup time per `@claude` invocation when the dependency cache is warm; slower on cold cache. Acceptable for the tasks that need it.

### Follow-up issue filing
- Bump permissions: `issues: read` → `issues: write`.
- Add `Bash(gh issue:*)` to the allowlist.

So Claude can open a tracking issue for deferred work instead of burying it in a PR comment that gets lost.

## Out of scope
- The same expansion for `claude-code-review.yml` (auto-trigger on `pull_request`). Reviews are review-only and shouldn't be filing issues or running long install steps on every push.

## Test plan
- [ ] After merge, `@claude` on a PR with a request like "regenerate the Rd for X" and confirm Claude runs `devtools::document()` rather than hand-editing the Rd.
- [ ] Ask `@claude` to "file a follow-up issue for $thing" and confirm the issue lands.
- [ ] Confirm cold-cache invocation time is acceptable (< 5 min added).

🤖 Generated with [Claude Code](https://claude.com/claude-code)