### PR TITLE
docs(copilot): lab manual overrides tidyverse; require explicit return()

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -538,7 +538,8 @@ expect_false(has_missing_values(complete_data))
 
 ## Code Style Guidelines
 
-- **Follow tidyverse style guide**: https://style.tidyverse.org
+- **Lab manual overrides tidyverse style**: Follow the [UCD-SeRG Lab Manual coding-style chapter](https://ucd-serg.github.io/lab-manual/coding-style.html) first; fall back to the [tidyverse style guide](https://style.tidyverse.org) only where the lab manual is silent. Where the two conflict, the lab manual wins.
+- **Use explicit `return()` statements**: Per the [lab manual](https://ucd-serg.github.io/lab-manual/coding-style/function-structure-and-documentation.html#explicit-return-statements) (which follows the [Google R Style Guide](https://google.github.io/styleguide/Rguide.html#use-explicit-returns)), always end functions with `return(value)` rather than relying on R's implicit final-expression return. This overrides the tidyverse style guide. Note: `return_linter` is currently disabled in `.lintr` for flexibility on older code, but new code should use explicit returns.
 - **Use native pipe**: `|>` not `%>%`
 - **Avoid redundant logical comparisons**: Use logical values directly (e.g., `if (is_ready)` not `if (is_ready == TRUE)`)
 - **Naming**: snake_case, acronyms may be uppercase (e.g., `prep_IDs_data`)

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -539,7 +539,7 @@ expect_false(has_missing_values(complete_data))
 ## Code Style Guidelines
 
 - **Lab manual overrides tidyverse style**: Follow the [UCD-SeRG Lab Manual coding-style chapter](https://ucd-serg.github.io/lab-manual/coding-style.html) first; fall back to the [tidyverse style guide](https://style.tidyverse.org) only where the lab manual is silent. Where the two conflict, the lab manual wins.
-- **Use explicit `return()` statements**: Per the [lab manual](https://ucd-serg.github.io/lab-manual/coding-style/function-structure-and-documentation.html#explicit-return-statements) (which follows the [Google R Style Guide](https://google.github.io/styleguide/Rguide.html#use-explicit-returns)), always end functions with `return(value)` rather than relying on R's implicit final-expression return. This overrides the tidyverse style guide. Note: `return_linter` is currently disabled in `.lintr` for flexibility on older code, but new code should use explicit returns.
+- **Use explicit `return()` statements**: Per the [lab manual](https://ucd-serg.github.io/lab-manual/coding-style/function-structure-and-documentation.html#explicit-return-statements) (which follows the [Google R Style Guide](https://google.github.io/styleguide/Rguide.html#use-explicit-returns)), always end functions with `return(value)` rather than relying on R's implicit final-expression return. This overrides the tidyverse style guide. Note: `return_linter` is currently disabled in `.lintr.R` for flexibility on older code, but new code should use explicit returns.
 - **Use native pipe**: `|>` not `%>%`
 - **Avoid redundant logical comparisons**: Use logical values directly (e.g., `if (is_ready)` not `if (is_ready == TRUE)`)
 - **Naming**: snake_case, acronyms may be uppercase (e.g., `prep_IDs_data`)

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: serodynamics
 Title: What the Package Does (One Line, Title Case)
-Version: 0.0.0.9054
+Version: 0.0.0.9055
 Authors@R: c(
     person("Peter", "Teunis", , "p.teunis@emory.edu", role = c("aut", "cph"),
            comment = "Author of the method and original code."),

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,11 @@
 # serodynamics (development version)
 
+* Clarified Code Style Guidelines in `.github/copilot-instructions.md`:
+  the UCD-SeRG Lab Manual takes precedence over the tidyverse style
+  guide where they conflict, and functions should end with an explicit
+  `return()` call per the lab manual / Google R Style Guide. This
+  closes a gap where `@claude` reviews were flagging explicit returns
+  as non-conforming.
 * Expanded what the `Claude Code` (`@claude`) workflow can do:
   - Install the full R toolchain (R, JAGS, pandoc, the apt system libs
     mirrored from `copilot-setup-steps.yml`, plus `devtools`, `roxygen2`,

--- a/inst/WORDLIST
+++ b/inst/WORDLIST
@@ -61,6 +61,7 @@ strat
 stratifications
 tbl
 testthat
+tidyverse
 toolchain
 unstratified
 vh

--- a/inst/WORDLIST
+++ b/inst/WORDLIST
@@ -14,7 +14,9 @@ PR's
 Postprocess
 Rhat
 SHA
+SeRG
 TSI
+UCD
 Vectorization
 Wasserstein
 allowlist


### PR DESCRIPTION
## Summary

- Adds a precedence rule to `.github/copilot-instructions.md` Code Style Guidelines: the [UCD-SeRG Lab Manual coding-style chapter](https://ucd-serg.github.io/lab-manual/coding-style.html) takes precedence over the tidyverse style guide where the two conflict.
- Adds an explicit `return()` bullet pointing at the [lab manual section](https://ucd-serg.github.io/lab-manual/coding-style/function-structure-and-documentation.html#explicit-return-statements) and the [Google R Style Guide](https://google.github.io/styleguide/Rguide.html#use-explicit-returns) it derives from.

## Motivation

On #141, the `@claude` review (e.g. [comment 4495071093](https://github.com/UCD-SERG/serodynamics/pull/141#issuecomment-4495071093)) asked to remove an explicit `return(jags_unpack_bind)` on the grounds that "the lab guide says to follow the tidyverse style guide, which avoids explicit `return()` at the end of a function." That's the opposite of what the lab manual actually says — but `copilot-instructions.md` only referenced tidyverse, with no mention of the lab manual override, so the bot's conclusion was internally consistent with the instructions it read. This change closes that gap so future reviews land on the correct rule.

## Test plan

- [ ] Skim the diff on `.github/copilot-instructions.md` to confirm wording and links read clearly.
- [ ] Click through both new links and confirm they resolve to the intended lab-manual sections.
- [ ] (Optional) Trigger a fresh `@claude` review on a small unrelated PR after merge and confirm the bot no longer flags explicit `return()` as a violation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)