### PR TITLE
ci(claude): temporarily swap @v1 → @beta to surface real SDK error

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -117,7 +117,11 @@ jobs:
 
       - name: Run Claude Code
         id: claude
-        uses: anthropics/claude-code-action@v1
+        # TEMP: swapped @v1 → @beta to surface the real underlying error
+        # being masked by the AJV obfuscation in @v1 (see upstream
+        # anthropics/claude-code-action#892 comment by ovceev 2026-03-10).
+        # Revert to @v1 once we have a clear error from the next trigger.
+        uses: anthropics/claude-code-action@beta
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
 


### PR DESCRIPTION
## Summary

- Swap the agent workflow's `anthropics/claude-code-action@v1` → `@beta` for one debug run.
- Goal: surface the *real* underlying error currently being masked as an obfuscated minified-JS frame from `sdk.mjs` (matches upstream [issue #892](https://github.com/anthropics/claude-code-action/issues/892)).

## Motivation

The `@claude review` workflow has been crashing during SDK init with no readable error — three deterministic failures (runs [26144000481](https://github.com/UCD-SERG/serodynamics/actions/runs/26144000481), [26144129682](https://github.com/UCD-SERG/serodynamics/actions/runs/26144129682), [26146565378](https://github.com/UCD-SERG/serodynamics/actions/runs/26146565378)) on PR #141, all at the same byte offset (`sdk.mjs:60:11252`) in the SDK's auth/credential init.

Adding `show_full_output: true` did not help, because the SDK throws before the child writes any stderr that could be piped through.

A maintainer-thread comment on #892 (ovceev, 2026-03-10) notes that `@beta` *does* surface the underlying error (in their case, `Credit balance is too low`). One debug trigger on `@beta` should tell us what's actually killing the child.

## Test plan

- [ ] Merge this PR.
- [ ] Trigger `@claude review` on PR #141 once.
- [ ] Capture the real error from the action log.
- [ ] Open a follow-up PR to revert to `@v1` (and decide whether to file or update an upstream issue based on what the error reveals).

🤖 Generated with [Claude Code](https://claude.com/claude-code)