### PR TITLE
ci(claude): revert to @v1, pin --model claude-opus-4-7

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -117,11 +117,7 @@ jobs:
 
       - name: Run Claude Code
         id: claude
-        # TEMP: swapped @v1 → @beta to surface the real underlying error
-        # being masked by the AJV obfuscation in @v1 (see upstream
-        # anthropics/claude-code-action#892 comment by ovceev 2026-03-10).
-        # Revert to @v1 once we have a clear error from the next trigger.
-        uses: anthropics/claude-code-action@beta
+        uses: anthropics/claude-code-action@v1
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
 
@@ -137,7 +133,13 @@ jobs:
           #     styler::style_pkg(), R CMD ...) — toolchain is installed above;
           #   * file follow-up issues for work deferred out of the current PR
           #     (gh issue create / comment / edit / view / list).
-          claude_args: '--allowed-tools "Bash(Rscript:*)" "Bash(R:*)" "Bash(R CMD:*)" "Bash(gh issue:*)"'
+          # Pin the model explicitly: the action's default points at
+          # claude-sonnet-4-20250514, which is retired and returns 404 from
+          # the API. The 404 in turn manifests as the obfuscated AJV crash
+          # in sdk.mjs documented in upstream issue #892. Once that issue
+          # is resolved (or the action's default is bumped), --model here
+          # can be dropped.
+          claude_args: '--model claude-opus-4-7 --allowed-tools "Bash(Rscript:*)" "Bash(R:*)" "Bash(R CMD:*)" "Bash(gh issue:*)"'
 
           # Surface the spawned `claude` CLI's stderr in the Actions log so
           # SDK init crashes (e.g. run 26144000481) show a real error


### PR DESCRIPTION
## Summary

- Revert the agent workflow from `anthropics/claude-code-action@beta` back to `@v1`.
- Pin `--model claude-opus-4-7` in `claude_args` so the action stops asking the API for a retired default model.

## Diagnosis (from #224's @beta debug trigger)

The @v1 SDK crashes documented in #224 were not a Claude-Code-Action bug *per se* — they were a `model: claude-sonnet-4-20250514` **404** from the Anthropic API being masked as the obfuscated `sdk.mjs` AJV crash. Confirmed by run [26147667637](https://github.com/UCD-SERG/serodynamics/actions/runs/26147667637), which on `@beta` produced a readable error:

```
API Error: 404 {"type":"error","error":{"type":"not_found_error","message":"model: claude-sonnet-4-20250514"},"request_id":"req_011CbDRtTEpspPCv6cL5kaaZ"}
```

`claude-sonnet-4-20250514` is the older Sonnet 4.0 ID that's no longer served. The action's default points there; pinning `--model claude-opus-4-7` routes around it.

The upstream "obfuscated SDK crash" issue ([anthropics/claude-code-action#892](https://github.com/anthropics/claude-code-action/issues/892)) is orthogonal — it's about the error message being illegible. That stays open upstream regardless of this fix.

## Test plan

- [ ] Merge.
- [ ] Trigger `@claude review` on PR #141 (or a smaller PR) and confirm a successful review run.
- [ ] If it works, drop a confirmation comment on upstream #892 noting the underlying cause for this signature.

🤖 Generated with [Claude Code](https://claude.com/claude-code)