### PR TITLE
ci(lint): fix invalid GitHub PAT format in lint-changed-files

### DIFF
--- a/.github/workflows/lint-changed-files.yaml
+++ b/.github/workflows/lint-changed-files.yaml
@@ -10,8 +10,6 @@ permissions: read-all
 jobs:
   lint-changed-files:
     runs-on: ubuntu-latest
-    env:
-      GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}
     steps:
       - uses: actions/checkout@v4
 
@@ -37,11 +35,18 @@ jobs:
 
       - name: Extract and lint files changed by this PR
         run: |
-          files <- gh::gh("GET https://api.github.com/repos/${{ github.repository }}/pulls/${{ github.event.pull_request.number }}/files")
+          Sys.unsetenv("GITHUB_PAT")
+
+          files <- gh::gh(
+            "GET https://api.github.com/repos/${{ github.repository }}/pulls/${{ github.event.pull_request.number }}/files",
+            .token = Sys.getenv("GITHUB_TOKEN")
+          )
+
           changed_files <- purrr::map_chr(files, "filename")
           all_files <- list.files(recursive = TRUE)
           exclusions_list <- as.list(setdiff(all_files, changed_files))
           lintr::lint_package(exclusions = exclusions_list)
         shell: Rscript {0}
         env:
+          GITHUB_TOKEN: ${{ github.token }}
           LINTR_ERROR_ON_LINT: true


### PR DESCRIPTION
## Problem

The `lint-changed-files` job has been failing on PRs (e.g. [run on #241](https://github.com/UCD-SERG/serodynamics/actions/runs/26609350923/job/78411596928?pr=241)) with:

```
Error in `validate_gh_pat()`:
! Invalid GitHub PAT format
```

**Root cause:** the R `gh` package reads the `GITHUB_PAT` env var and runs `validate_gh_pat()` on it. The auto-provisioned `secrets.GITHUB_TOKEN` is now a `ghs_`-style server-to-server token whose format `gh` rejects (it only accepts 40-hex, `ghp_`, or `github_pat_`). So the "Extract and lint files changed by this PR" step aborts before any linting runs.

see https://github.com/r-lib/gh/issues/231 and https://github.com/r-lib/gh/pull/232 for details

## Fix

Unset `GITHUB_PAT` and pass the token explicitly via `.token=` (which bypasses the PAT format check), setting `GITHUB_TOKEN: ${{ github.token }}` on the step. This mirrors the fix already applied in the [shigella repo](https://github.com/UCD-SERG/shigella).

Once merged into `main`, branches (including #241) will pick it up after merging `main` in.

🤖 Generated with [Claude Code](https://claude.com/claude-code)