### PR TITLE
ci+fix: strict lifecycle deprecations, idiom review guidance, bot-skip review

### DIFF
--- a/.Rbuildignore
+++ b/.Rbuildignore
@@ -5,6 +5,7 @@
 ^project.*\.tgz$
 ^data-raw$
 ^README\.Rmd$
+^CLAUDE\.md$
 ^codecov\.yml$
 ^_pkgdown\.yml$
 ^docs$

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -553,6 +553,13 @@ expect_false(has_missing_values(complete_data))
 - **Quarto vignettes**: Use Quarto-style chunk options with `#|` prefix (e.g., `#| label: my-chunk`, `#| eval: false`) instead of R Markdown comma-separated options (e.g., `{r my-chunk, eval=FALSE}`)
 - **Tidyverse replacements**: Use tidyverse/modern replacements for base R functions where available (e.g., `sessioninfo::session_info()` instead of `sessionInfo()`, `tibble::tibble()` instead of `data.frame()`, `readr::read_csv()` instead of `read.csv()`)
 - **Write tidy code**: Keep code clean, readable, and well-organized. Follow consistent formatting, use meaningful variable names, and maintain logical structure
+- **Use tidy-selection, not data-masking, in selection contexts**: In `select()`, `rename()`, `summarize(.by = )` / `group_by()`, `across(.cols = )`, `pivot_*(names_from = )`, and join `by =`, select columns named by a variable with `all_of()` / `any_of()` (e.g. `select(any_of(c("a", "b", "new_name" = var)))`), and use bare names or `all_of()` in `.by`. Do **not** reach for the `.data` pronoun (`.data[[var]]`, `.data$x`) there — that pronoun belongs in *data-masking* verbs (`mutate()`, `filter()`, `summarize()` expressions). Using `.data[[var]]` in a selection context is a *soft* deprecation and may not warn at runtime, so it is easy to miss — but it should be rewritten.
+- **Collapse branching that only varies columns**: An `if`/`else` whose only job is to change which columns are selected, renamed, or joined can almost always be replaced by a single `any_of()` / `all_of()` selection or a single tidyselect-keyed join. Prefer one parameterized pipeline over two near-identical stratified/unstratified branches.
+- **Prefer dplyr joins over base `merge()`**: Use `dplyr::left_join()` / `right_join()` with `by = join_by(...)` rather than `merge()` for readability and consistency.
+
+### Review focus: convoluted / non-idiomatic code
+
+When reviewing (human or AI), treat the three points above as in-scope findings, not optional nits. Beyond correctness, call out code that is functionally fine but unnecessarily convoluted or non-idiomatic, and show the simpler, more declarative form. The canonical authority is the [UCD-SeRG Lab Manual coding-style chapter](https://ucd-serg.github.io/lab-manual/coding-style.html).
 
 ## Documentation and Evidence Standards
 

--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -21,11 +21,19 @@ concurrency:
 
 jobs:
   claude-review:
-    # Optional: Filter by PR author
-    # if: |
-    #   github.event.pull_request.user.login == 'external-contributor' ||
-    #   github.event.pull_request.user.login == 'new-developer' ||
-    #   github.event.pull_request.author_association == 'FIRST_TIME_CONTRIBUTOR'
+    # Skip (don't fail) when a bot triggered this run. When @claude or the
+    # Copilot agent pushes a commit to a PR branch it fires `synchronize`,
+    # which would otherwise kick off — and red-X — an automatic review of a
+    # bot-authored diff. `github.event.sender.type` is the account that
+    # triggered the event ('Bot' for app/bot pushers); the `actor` guard is
+    # belt-and-suspenders for `*[bot]` logins. A false `if:` marks the job
+    # *skipped*, not failed, which is safe here because this check is not
+    # branch-protection-required. (No `workflow_dispatch ||` bypass is
+    # needed: unlike sibling repos, this repo's claude.yml does not
+    # re-dispatch reviews.)
+    if: >-
+      github.event.sender.type != 'Bot' &&
+      !endsWith(github.actor, '[bot]')
 
     runs-on: ubuntu-latest
     permissions:

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,56 @@
+# Claude / AI agent instructions for serodynamics
+
+This file is read by Claude Code sessions and by the `@claude` GitHub
+review agent. The canonical, detailed contributor guide lives in
+[`.github/copilot-instructions.md`](.github/copilot-instructions.md) —
+**follow it** for setup, build, test, documentation, and style. This
+file adds review-specific emphasis on top of that guide.
+
+## Lab-wide style authority
+
+Follow the
+[UCD-SeRG Lab Manual coding-style chapter](https://ucd-serg.github.io/lab-manual/coding-style.html)
+first; fall back to the [tidyverse style guide](https://style.tidyverse.org)
+only where the lab manual is silent. Where the two conflict, the lab
+manual wins.
+
+## Idiomatic-code review focus
+
+Beyond correctness, flag code that is functionally fine but
+unnecessarily convoluted or non-idiomatic, and suggest the idiomatic
+form. Treat these as in-scope review findings, not optional nits:
+
+- **Data-masking in tidy-selection contexts.** Flag the `.data` pronoun
+  (`.data$x`, `.data[[var]]`) used inside *selection* contexts —
+  `select()`, `rename()`, `summarize(.by = )` / `group_by()`,
+  `across(.cols = )`, `pivot_*(names_from = )`, and join `by =`. Use
+  `all_of()` / `any_of()` to select columns named by a variable, and
+  bare column names (or `all_of()`) in `.by`. The `.data` pronoun
+  belongs in *data-masking* verbs (`mutate()`, `filter()`,
+  `summarize()` expressions), not in selection. Note that
+  `.data[[var]]` in a selection context is a *soft* deprecation, so it
+  may not emit a warning at runtime — flag it on sight.
+
+- **Branching that only varies columns.** Flag `if`/`else` whose sole
+  purpose is to vary which columns are selected, renamed, or joined.
+  These usually collapse into a single `any_of()` / `all_of()`
+  selection (e.g. `select(any_of(c(..., "Stratification" = strat)))`)
+  or a single join with a tidyselect `by =`, removing the branch
+  entirely.
+
+- **Base `merge()` over dplyr joins.** Prefer `dplyr::left_join()` /
+  `right_join()` with `by = join_by(...)` for clarity and consistency
+  with the rest of the codebase.
+
+- **Near-duplicate stratified / unstratified paths.** Prefer one
+  parameterized pipeline over two near-identical branches.
+
+- Generally: when a more declarative tidyverse construct expresses the
+  same thing with less control flow, say so and show the simpler form.
+
+## Deprecation strictness
+
+The test suite sets `options(lifecycle_verbosity = "error")` (see
+`tests/testthat/setup.R`), so lifecycle deprecations — including
+`.data`-in-tidyselect — fail the tests rather than passing silently.
+Keep new code free of deprecated calls.

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: serodynamics
 Title: What the Package Does (One Line, Title Case)
-Version: 0.0.0.9055
+Version: 0.0.0.9056
 Authors@R: c(
     person("Peter", "Teunis", , "p.teunis@emory.edu", role = c("aut", "cph"),
            comment = "Author of the method and original code."),

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,24 @@
 # serodynamics (development version)
 
+* The test suite now sets `options(lifecycle_verbosity = "error")` (via
+  `tests/testthat/setup.R`), so tidyverse lifecycle deprecations -
+  including soft deprecations such as using the `.data` pronoun in a
+  tidy-selection context - fail the tests instead of passing silently.
+* Updated the internals of `calc_fit_mod()` to use tidy-selection
+  (`all_of()` and bare column-name strings) instead of the `.data`
+  pronoun in `select()`, `.by`, and `pivot_wider()` contexts, removing
+  a soft deprecation surfaced by the stricter test option above. No
+  change to behavior or output.
+* The `Claude Code Review` workflow now skips (rather than fails) when a
+  bot triggered the run, so a commit pushed by `@claude` or the Copilot
+  agent no longer produces a red review check.
+* Added `CLAUDE.md` and expanded the Code Style Guidelines in
+  `.github/copilot-instructions.md` to direct reviewers (human and AI)
+  to flag unnecessarily convoluted or non-idiomatic code - in
+  particular data-masking used in tidy-selection contexts and
+  `if`/`else` branching that only varies which columns are selected,
+  renamed, or joined.
+
 * Clarified Code Style Guidelines in `.github/copilot-instructions.md`:
   the UCD-SeRG Lab Manual takes precedence over the tidyverse style
   guide where they conflict, and functions should end with an explicit

--- a/R/calc_fit_mod.R
+++ b/R/calc_fit_mod.R
@@ -19,18 +19,17 @@
 #' @keywords internal
 calc_fit_mod <- function(modeled_dat, 
                          original_data) {
-  original_data <- original_data |> 
+  original_data <- original_data |>
     use_att_names() |>
-    select(.data$Subject, .data$Iso_type, .data$t, .data$result)
-  
+    select(all_of(c("Subject", "Iso_type", "t", "result")))
+
   # Preparing modeled data
   modeled_dat <- modeled_dat |>
-    dplyr::summarize(.by = c(.data$Parameter, .data$Iso_type, 
-                             .data$Stratification, 
-                             .data$Subject),
+    dplyr::summarize(.by = all_of(c("Parameter", "Iso_type",
+                                    "Stratification", "Subject")),
                      med_value = stats::median(.data$value)) |>
-    tidyr::pivot_wider(names_from = .data$Parameter, 
-                       values_from = .data$med_value)
+    tidyr::pivot_wider(names_from = "Parameter",
+                       values_from = "med_value")
 
   # Matching input data with modeled data
   matched_dat <- merge(modeled_dat, original_data, 
@@ -42,6 +41,6 @@ calc_fit_mod <- function(modeled_dat,
     mutate(fitted = ab(.data$t, .data$y0, .data$y1, .data$t1,
                        .data$alpha, .data$shape),
            residual = .data$result - .data$fitted) |>
-    select(.data$Subject, .data$Iso_type, .data$t, .data$fitted, .data$residual)
+    select(all_of(c("Subject", "Iso_type", "t", "fitted", "residual")))
   fitted_dat
 }

--- a/inst/WORDLIST
+++ b/inst/WORDLIST
@@ -26,6 +26,7 @@ biomarker
 biomarkers
 colour
 darwin
+deprecations
 dev
 dobson
 dotplots
@@ -40,6 +41,7 @@ hyperpriors
 iso
 isotype
 isotypes
+lifecycle
 libm
 libs
 linux

--- a/tests/testthat/setup.R
+++ b/tests/testthat/setup.R
@@ -1,0 +1,13 @@
+# Escalate lifecycle deprecation signals to errors during testing.
+#
+# Many tidyverse deprecations (e.g. using the `.data` pronoun in a
+# tidy-selection context such as `select()` or `.by =`) are *soft*
+# deprecations: `lifecycle::deprecate_soft()` only signals when called
+# from the global environment or the package under development, so they
+# stay silent inside an installed-package test run -- and `options(warn =
+# 2)` never catches them because the signal is suppressed before it
+# becomes a warning. Setting `lifecycle_verbosity = "error"` overrides
+# that suppression and turns every lifecycle deprecation into a hard
+# error, so non-idiomatic / soon-to-be-removed calls fail CI here rather
+# than surfacing later as a broken build against a newer dependency.
+options(lifecycle_verbosity = "error") # nolint: undesirable_function_linter.


### PR DESCRIPTION
## Why

On #240, a reviewer (d-morrison) caught `.data` data-masking used in a tidy-selection context in `R/calc_fit_mod.R` — and **none** of the AI review workflows flagged it. Root cause: it's a *soft* deprecation (silent in installed-package test runs, so `options(warn = 2)` never catches it), and the `@claude`/Copilot reviewers were optimizing for "does the fix work," not idiom. This PR closes both gaps and cleans up the existing offenders.

## What

1. **Strict lifecycle deprecations in tests** — `tests/testthat/setup.R` sets `options(lifecycle_verbosity = "error")`, which overrides soft-deprecation suppression so lifecycle deprecations (incl. `.data`-in-tidyselect) fail the suite. (Scope: all test runs.)
2. **De-deprecate `calc_fit_mod()`** — the only file on `main` using `.data` in tidyselect contexts. Converted `select()`, `.by`, and `pivot_wider(names_from/values_from)` to `all_of()` / string selection. Data-masking `.data$` in `summarize()`/`mutate()` expressions left as-is. **No behavior/output change.**
3. **Skip-not-fail Claude review on bot commits** — `claude-code-review.yml` gains a job-level `if:` that skips when `github.event.sender.type == 'Bot'` (or actor is `*[bot]`). Ports the pattern already used in `gdl`/`asaurl`/`bcs`/`rme`/`serocalculator`. `main` is not branch-protected, so a skipped check doesn't block merge.
4. **Idiom review guidance for all AIs** — new `CLAUDE.md` (the file `@claude` looks for) + an expanded Code Style / "Review focus" section in `.github/copilot-instructions.md`. Directs reviewers to flag data-masking-in-tidyselect, `if`/`else` that only varies columns, and base `merge()` over dplyr joins, citing the lab-manual coding-style chapter.

## Validation

- `spelling::spell_check_package()` → no errors (added `deprecations`, `lifecycle` to WORDLIST).
- `lintr::lint()` on `calc_fit_mod.R` and `setup.R` → no lints.
- Isolated check under `lifecycle_verbosity = "error"`: the new `all_of()` forms pass; the old `.data`-in-`select()` form errors — confirming both that the option catches the issue and that the fix resolves it.
- Full JAGS test suite not runnable locally (arch mismatch) — relying on CI.

## Note on #240

This touches `R/calc_fit_mod.R`, which #240 is concurrently rewriting. Per discussion, **@sschildhauer to resolve the merge conflict on the #240 branch** after this lands. #240's idiomatic rewrite (the `any_of()` + join restructuring from the inline review) supersedes this minimal de-deprecation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)