### PR TITLE
Add cleanup-pr-previews with gh-pages history compaction (closes #260)

### DIFF
--- a/.github/workflows/cleanup-pr-previews.yml
+++ b/.github/workflows/cleanup-pr-previews.yml
@@ -1,0 +1,28 @@
+# Housekeeping half of the PR-preview family, delegated to the reusable
+# cleanup-pr-previews workflow in d-morrison/gha. Periodically deletes gh-pages
+# preview directories for PRs that are no longer open, and (compact-history)
+# orphan-squashes gh-pages to a single commit so the deleted snapshots stop
+# bloating the repo. The calling job grants contents: write so the reusable can
+# commit the deletions / force-push the compacted branch back to gh-pages.
+name: Clean up PR Previews
+
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: '0 0 * * 0' # Weekly on Sunday at midnight UTC
+
+# Only one cleanup at a time: a manual dispatch overlapping the scheduled run
+# would otherwise race on gh-pages. The reusable's --force-with-lease keeps that
+# data-safe, but serializing avoids the wasted runner and noisy retries.
+concurrency:
+  group: gh-pages-cleanup
+  cancel-in-progress: false
+
+jobs:
+  cleanup:
+    permissions:
+      contents: write
+      pull-requests: read
+    uses: d-morrison/gha/.github/workflows/cleanup-pr-previews.yml@v2
+    with:
+      compact-history: true

--- a/.github/workflows/cleanup-pr-previews.yml
+++ b/.github/workflows/cleanup-pr-previews.yml
@@ -4,6 +4,8 @@
 # orphan-squashes gh-pages to a single commit so the deleted snapshots stop
 # bloating the repo. The calling job grants contents: write so the reusable can
 # commit the deletions / force-push the compacted branch back to gh-pages.
+#
+# Pinned to the @v2 moving major tag.
 name: Clean up PR Previews
 
 on:

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: serodynamics
 Title: Modeling Longitudinal Antibody Responses to Infection
-Version: 0.1.0.9003
+Version: 0.1.0.9004
 Authors@R: c(
     person("Peter", "Teunis", , "p.teunis@emory.edu", role = c("aut", "cph"),
            comment = c("Author of the method and original code.",

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,9 @@
 # serodynamics (development version)
 
+## Internal
+
+* Added a scheduled `Clean up PR Previews` workflow that prunes closed-PR `gh-pages` previews and compacts `gh-pages` history, so deleted render snapshots stop bloating the repo (closes #260).
+
 ## New features
 * Renamed user-facing functions for clarity (#241):
   - `run_mod()` → `run_serodynamics()`


### PR DESCRIPTION
Adopts the `cleanup-pr-previews` reusable (d-morrison/gha#136) with `compact-history: true`: prune closed-PR previews and orphan-squash `gh-pages` to one commit, so ~1046 deleted snapshots stop bloating the repo (~229 MB `.git`). Branch-based Pages, previews preserved, `--force-with-lease`. Same fix as ucdavis/epi204#352. After merge, one `workflow_dispatch` reclaims the existing history.

🤖 Generated with [Claude Code](https://claude.com/claude-code)