### PR TITLE
Idiomatic-code review focus: add roxygen doc-reuse / ... passthrough item

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -59,6 +59,19 @@ form. Treat these as in-scope review findings, not optional nits:
 - Generally: when a more declarative tidyverse construct expresses the
   same thing with less control flow, say so and show the simpler form.
 
+- **Roxygen doc reuse and `...` passthrough.** Flag a `@param` description
+  or a prose section copy-pasted between roxygen blocks instead of using
+  [roxygen2's tag-reuse tags](https://roxygen2.r-lib.org/reference/tags-reuse.html)
+  (`@inheritParams`, `@inheritDotParams`, `@inheritSection`) — reused docs
+  stay in sync when the source function's docs change; copy-pasted docs
+  silently drift. Also flag a wrapper function that manually re-declares
+  and relays arguments it never touches itself instead of forwarding
+  [`...`](https://adv-r.hadley.nz/functions.html?q=dot-dot#fun-dot-dot-dot)
+  straight to the subfunction (documented via `@inheritDotParams`). This is
+  a global standing rule from the
+  [`d-morrison/ai-config`](https://github.com/d-morrison/ai-config) corpus
+  (`shared/coding/reuse-docs-and-args.md`).
+
 ## Deprecation strictness
 
 The test suite sets `options(lifecycle_verbosity = "error")` (see

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: serodynamics
 Title: Modeling Longitudinal Antibody Responses to Infection
-Version: 0.1.0.9005
+Version: 0.1.0.9006
 Authors@R: c(
     person("Peter", "Teunis", , "p.teunis@emory.edu", role = c("aut", "cph"),
            comment = c("Author of the method and original code.",

--- a/NEWS.md
+++ b/NEWS.md
@@ -3,6 +3,7 @@
 ## Internal
 
 * Added a scheduled `Clean up PR Previews` workflow that prunes closed-PR `gh-pages` previews and compacts `gh-pages` history, so deleted render snapshots stop bloating the repo (closes #260).
+* Added a `CLAUDE.md` review-guideline item flagging roxygen doc copy-paste (use `@inheritParams`/`@inheritDotParams`/`@inheritSection` instead) and manual argument relaying (use `...` passthrough instead) (closes #262).
 
 ## New features
 * Renamed user-facing functions for clarity (#241):

--- a/inst/WORDLIST
+++ b/inst/WORDLIST
@@ -61,11 +61,13 @@ nmc
 onwards
 pandoc
 params
+passthrough
 pkgdown
 prec
 precisions
 preinstalling
 rhat
+roxygen
 serocalculator
 seroconversion
 seroepidemiologic


### PR DESCRIPTION
## Summary
- Adds a review-guideline item to `CLAUDE.md`'s "Idiomatic-code review focus" list: flag `@param`/section text copy-pasted between roxygen blocks instead of using [roxygen2's tag-reuse tags](https://roxygen2.r-lib.org/reference/tags-reuse.html) (`@inheritParams`, `@inheritDotParams`, `@inheritSection`), and wrapper functions that manually relay arguments instead of forwarding `...` (see [Advanced R](https://adv-r.hadley.nz/functions.html?q=dot-dot#fun-dot-dot-dot)).
- Mirrors [d-morrison/ai-config#474](https://github.com/d-morrison/ai-config/pull/474) and [d-morrison/gha#222](https://github.com/d-morrison/gha/pull/222).

Closes #262

## Test plan
- [x] Docs-only change; no code affected.


---
_Generated by [Claude Code](https://claude.ai/code/session_01198A86RPQi95smG64YwdJG)_