### PR TITLE
Embed d-morrison/ai-config as a git submodule

### DIFF
--- a/.Rbuildignore
+++ b/.Rbuildignore
@@ -11,6 +11,9 @@
 ^docs$
 ^pkgdown$
 ^\.github$
+^\.claude$
+^\.ai-config$
+^\.gitmodules$
 ^LICENSE\.md$
 ^serodynamics\.Rcheck$
 ^serodynamics.*\.tar\.gz$

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,13 @@
+{
+  "extraKnownMarketplaces": {
+    "d-morrison": {
+      "source": {
+        "source": "github",
+        "repo": "d-morrison/ai-config"
+      }
+    }
+  },
+  "enabledPlugins": {
+    "ai-config@d-morrison": true
+  }
+}

--- a/.github/workflows/bump-submodule.yml
+++ b/.github/workflows/bump-submodule.yml
@@ -1,0 +1,26 @@
+# Periodically bump the .ai-config submodule to its upstream HEAD and open a
+# PR when it moves. Requires Settings -> Actions -> General -> "Allow GitHub
+# Actions to create and approve pull requests" (the integrated GITHUB_TOKEN
+# opens the PR).
+name: Bump submodule
+
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: '0 6 * * 1' # Weekly on Monday at 06:00 UTC
+
+jobs:
+  bump:
+    permissions:
+      contents: write
+      pull-requests: write
+    uses: d-morrison/gha/.github/workflows/bump-submodule.yml@v1
+    with:
+      submodule-path: .ai-config
+      # remote-branch: main        # defaults to the submodule's configured branch
+    secrets:
+      # Needed only for private submodules; omit for public ones (ai-config is public).
+      SUBMODULES_TOKEN: ${{ secrets.SUBMODULES_TOKEN }}
+      # Set only if the bot must push to a protected branch; otherwise omit and
+      # the push falls back to GITHUB_TOKEN.
+      WORKFLOW_TOKEN: ${{ secrets.WORKFLOW_TOKEN }}

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,4 @@
+[submodule ".ai-config"]
+	path = .ai-config
+	url = https://github.com/d-morrison/ai-config.git
+	branch = main

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -10,7 +10,7 @@ file adds review-specific emphasis on top of that guide.
 
 The `.ai-config` git submodule pins a copy of
 [`d-morrison/ai-config`](https://github.com/d-morrison/ai-config) — the
-corpus this file's review guidelines cite throughout (`shared/` fragments,
+corpus one of this file's review guidelines cites (`shared/` fragments,
 skills, memories). A scheduled `Bump submodule` workflow
 (`.github/workflows/bump-submodule.yml`) keeps the pin fresh and opens a PR
 when it drifts.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -6,6 +6,15 @@ review agent. The canonical, detailed contributor guide lives in
 **follow it** for setup, build, test, documentation, and style. This
 file adds review-specific emphasis on top of that guide.
 
+## ai-config submodule
+
+The `.ai-config` git submodule pins a copy of
+[`d-morrison/ai-config`](https://github.com/d-morrison/ai-config) — the
+corpus this file's review guidelines cite throughout (`shared/` fragments,
+skills, memories). A scheduled `Bump submodule` workflow
+(`.github/workflows/bump-submodule.yml`) keeps the pin fresh and opens a PR
+when it drifts.
+
 ## Lab-wide style authority
 
 Follow the

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -15,6 +15,12 @@ skills, memories). A scheduled `Bump submodule` workflow
 (`.github/workflows/bump-submodule.yml`) keeps the pin fresh and opens a PR
 when it drifts.
 
+`.claude/settings.json` also registers ai-config's Claude Code plugin
+marketplace, so a Claude Code web/cloud session opened directly on this repo
+(where `~/.claude` starts empty) loads its skills as `ai-config:`-namespaced
+commands. This is separate from the `@claude` CI bot, which loads skills only
+from a committed `.claude/skills/` directory, not from `enabledPlugins`.
+
 ## Lab-wide style authority
 
 Follow the

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: serodynamics
 Title: Modeling Longitudinal Antibody Responses to Infection
-Version: 0.1.0.9006
+Version: 0.1.0.9007
 Authors@R: c(
     person("Peter", "Teunis", , "p.teunis@emory.edu", role = c("aut", "cph"),
            comment = c("Author of the method and original code.",

--- a/NEWS.md
+++ b/NEWS.md
@@ -2,7 +2,7 @@
 
 ## Internal
 
-* Embedded [`d-morrison/ai-config`](https://github.com/d-morrison/ai-config) as a `.ai-config` git submodule, with a scheduled `Bump submodule` workflow to keep the pin fresh (closes #264).
+* Embedded [`d-morrison/ai-config`](https://github.com/d-morrison/ai-config) as a `.ai-config` git submodule, with a scheduled `Bump submodule` workflow to keep the pin fresh, and registered its Claude Code plugin marketplace in `.claude/settings.json` so cloud/web sessions opened on this repo load its skills (closes #264).
 * Added a scheduled `Clean up PR Previews` workflow that prunes closed-PR `gh-pages` previews and compacts `gh-pages` history, so deleted render snapshots stop bloating the repo (closes #260).
 * Added a `CLAUDE.md` review-guideline item flagging roxygen doc copy-paste (use `@inheritParams`/`@inheritDotParams`/`@inheritSection` instead) and manual argument relaying (use `...` passthrough instead) (closes #262).
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -2,6 +2,7 @@
 
 ## Internal
 
+* Embedded [`d-morrison/ai-config`](https://github.com/d-morrison/ai-config) as a `.ai-config` git submodule, with a scheduled `Bump submodule` workflow to keep the pin fresh (closes #264).
 * Added a scheduled `Clean up PR Previews` workflow that prunes closed-PR `gh-pages` previews and compacts `gh-pages` history, so deleted render snapshots stop bloating the repo (closes #260).
 * Added a `CLAUDE.md` review-guideline item flagging roxygen doc copy-paste (use `@inheritParams`/`@inheritDotParams`/`@inheritSection` instead) and manual argument relaying (use `...` passthrough instead) (closes #262).
 

--- a/inst/WORDLIST
+++ b/inst/WORDLIST
@@ -77,6 +77,7 @@ seroresponse
 seroresponses
 strat
 stratifications
+submodule
 tbl
 testthat
 tibble


### PR DESCRIPTION
Closes #264

## Summary
- Adds [`d-morrison/ai-config`](https://github.com/d-morrison/ai-config) as a `.ai-config` git submodule, pinned to its current `main` HEAD, mirroring the pattern `UCD-SERG/lab-manual` already uses.
- Adds `.github/workflows/bump-submodule.yml`, a scheduled caller of `d-morrison/gha`'s `bump-submodule` reusable workflow (`@v1`), to keep the pin fresh automatically and open a PR when it drifts.
- Notes the submodule in `CLAUDE.md`.
- Bumps `DESCRIPTION` version and adds a `NEWS.md` entry per repo convention.

## Test plan
- [x] `git submodule status` shows `.ai-config` checked out at the pinned commit.
- [x] `.github/workflows/bump-submodule.yml` mirrors `d-morrison/gha`'s published `examples/bump-submodule.yml` caller stub.
- CI: R-CMD-check, lint, tests, docs, spelling, version-check, and NEWS checks should all be unaffected (no R/package source touched).

Note: this repo's Settings → Actions → General needs "Allow GitHub Actions to create and approve pull requests" enabled for the scheduled `bump-submodule` workflow to open its own PRs (same requirement noted in the `d-morrison/gha` example stub) — flagging in case that isn't already on.
