### PR TITLE
Temporarily disable automatic claude-review PR trigger

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -6,8 +6,10 @@
 name: Claude Code Review
 
 on:
-  pull_request:
-    types: [opened, synchronize, ready_for_review, reopened]
+  # Automatic review on PR events is temporarily disabled (see #266).
+  # Re-enable by uncommenting the `pull_request:` trigger below.
+  # pull_request:
+  #   types: [opened, synchronize, ready_for_review, reopened]
   workflow_dispatch:
     inputs:
       pr_number:

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: serodynamics
 Title: Modeling Longitudinal Antibody Responses to Infection
-Version: 0.1.0.9006
+Version: 0.1.0.9007
 Authors@R: c(
     person("Peter", "Teunis", , "p.teunis@emory.edu", role = c("aut", "cph"),
            comment = c("Author of the method and original code.",


### PR DESCRIPTION
## Summary
- Comments out the `pull_request` trigger in `.github/workflows/claude-code-review.yml` so the Claude review no longer runs automatically on PR events (opened/synchronize/ready_for_review/reopened).
- Keeps the `workflow_dispatch` trigger intact, so the review can still be manually re-run (e.g. via `claude.yml`'s re-dispatch after an `@claude` run pushes commits, or a manual `gh workflow run`).
- The commented-out trigger stays in the file with a pointer back to this change, so re-enabling later is a one-line uncomment rather than reconstructing the workflow.

Closes #266

## Test plan
- [x] Confirmed the workflow file still parses as valid YAML (no other keys touched).
- [ ] After merge, confirm no automatic `Claude Code Review` run fires on the next PR opened against `main`.
- [ ] When ready to re-enable, uncomment the `pull_request:` block and verify the automatic review fires again on a test PR.


---
_Generated by [Claude Code](https://claude.ai/code/session_01BrTphYsw9SfzMA4Uj25K6B)_