### PR TITLE
Fix missing dispatch for explicit @claude review requests

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -33,10 +33,19 @@ jobs:
       apt-packages: jags
 
   dispatch-explicit-review:
+    # The `claude` job above delegates its trusted-author gate to the reusable
+    # workflow, but this job is local, so it must gate itself -- and it is the
+    # only gate on this path: claude-code-review.yml is workflow_dispatch-only
+    # and enforces nothing of its own, so without an author-association check
+    # any commenter (including author_association == NONE) could spend
+    # CLAUDE_CODE_OAUTH_TOKEN by writing "@claude review" on a PR.
+    # OWNER/MEMBER matches the gate pr-commands.yaml already applies to its
+    # /document and /style commands.
     if: >-
       github.event_name == 'issue_comment' &&
       github.event.issue.pull_request &&
-      github.event.sender.type != 'Bot'
+      github.event.sender.type != 'Bot' &&
+      contains(fromJSON('["OWNER","MEMBER"]'), github.event.comment.author_association)
     runs-on: ubuntu-latest
     permissions:
       actions: write

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -31,3 +31,27 @@ jobs:
       # setup-r defaults true and r-extra-packages' default `local::.` installs
       # the package (and its rjags/runjags deps) on top of JAGS.
       apt-packages: jags
+
+  dispatch-explicit-review:
+    if: >-
+      github.event_name == 'issue_comment' &&
+      github.event.issue.pull_request &&
+      github.event.sender.type != 'Bot' &&
+      contains(github.event.comment.body, '@claude')
+    runs-on: ubuntu-latest
+    permissions:
+      actions: write
+    env:
+      GH_TOKEN: ${{ github.token }}
+    steps:
+      - name: Dispatch Claude Code Review for explicit review requests
+        run: |
+          comment_body=$(jq -r '.comment.body // ""' "$GITHUB_EVENT_PATH")
+          shopt -s nocasematch
+          if [[ "$comment_body" =~ @claude[[:space:][:punct:]]*(please[[:space:]]+)?review([[:space:][:punct:]]|$) ]]; then
+            gh workflow run "claude-code-review.yml" \
+              --repo "$GITHUB_REPOSITORY" \
+              -f pr_number="${{ github.event.issue.number }}"
+          else
+            echo "Comment is not an explicit @claude review request; skipping dispatch."
+          fi

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -36,8 +36,7 @@ jobs:
     if: >-
       github.event_name == 'issue_comment' &&
       github.event.issue.pull_request &&
-      github.event.sender.type != 'Bot' &&
-      contains(github.event.comment.body, '@claude')
+      github.event.sender.type != 'Bot'
     runs-on: ubuntu-latest
     permissions:
       actions: write


### PR DESCRIPTION
## Summary
- add a dedicated `dispatch-explicit-review` job in `.github/workflows/claude.yml`
- dispatch `claude-code-review.yml` when a PR issue comment is an explicit `@claude ... review` request
- keep dispatch independent of whether the Claude run produced new commits

## Why
The `@claude, please review` request on #230 did not create a review run when no new commits were pushed. This ensures explicit review requests always trigger review dispatch.