### PR TITLE
Remove the local dispatch-explicit-review job

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -34,8 +34,9 @@ jobs:
 
 # There is deliberately no local review-dispatch job here. One existed, to
 # cover `@claude, please review` -- a phrasing the reusable workflow's own
-# matcher missed (#230). d-morrison/gha#341 fixed that matcher upstream, so
-# the local job became a duplicate: a plain `@claude review` matched both and
+# matcher missed. d-morrison/gha#341 fixed that matcher upstream, so the
+# local job became a duplicate: a plain `@claude review` matched both and
 # dispatched two paid review runs, which could review different heads since
-# the local job had no `needs: claude` (#277). Dispatch now happens only in
-# the reusable workflow, which applies its own trusted-author gate.
+# the local job had no `needs: claude`. See #277 for both halves. Dispatch
+# now happens only in the reusable workflow, which applies its own
+# trusted-author gate.

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -32,34 +32,10 @@ jobs:
       # the package (and its rjags/runjags deps) on top of JAGS.
       apt-packages: jags
 
-  dispatch-explicit-review:
-    # The `claude` job above delegates its trusted-author gate to the reusable
-    # workflow, but this job is local, so it must gate itself -- and it is the
-    # only gate on this path: claude-code-review.yml is workflow_dispatch-only
-    # and enforces nothing of its own, so without an author-association check
-    # any commenter (including author_association == NONE) could spend
-    # CLAUDE_CODE_OAUTH_TOKEN by writing "@claude review" on a PR.
-    # OWNER/MEMBER matches the gate pr-commands.yaml already applies to its
-    # /document and /style commands.
-    if: >-
-      github.event_name == 'issue_comment' &&
-      github.event.issue.pull_request &&
-      github.event.sender.type != 'Bot' &&
-      contains(fromJSON('["OWNER","MEMBER"]'), github.event.comment.author_association)
-    runs-on: ubuntu-latest
-    permissions:
-      actions: write
-    env:
-      GH_TOKEN: ${{ github.token }}
-    steps:
-      - name: Dispatch Claude Code Review for explicit review requests
-        run: |
-          comment_body=$(jq -r '.comment.body // ""' "$GITHUB_EVENT_PATH")
-          shopt -s nocasematch
-          if [[ "$comment_body" =~ @claude[[:space:][:punct:]]*(please[[:space:]]+)?review([[:space:][:punct:]]|$) ]]; then
-            gh workflow run "claude-code-review.yml" \
-              --repo "$GITHUB_REPOSITORY" \
-              -f pr_number="${{ github.event.issue.number }}"
-          else
-            echo "Comment is not an explicit @claude review request; skipping dispatch."
-          fi
+# There is deliberately no local review-dispatch job here. One existed, to
+# cover `@claude, please review` -- a phrasing the reusable workflow's own
+# matcher missed (#230). d-morrison/gha#341 fixed that matcher upstream, so
+# the local job became a duplicate: a plain `@claude review` matched both and
+# dispatched two paid review runs, which could review different heads since
+# the local job had no `needs: claude` (#277). Dispatch now happens only in
+# the reusable workflow, which applies its own trusted-author gate.

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: serodynamics
 Title: Modeling Longitudinal Antibody Responses to Infection
-Version: 0.1.0.9010
+Version: 0.1.0.9011
 Authors@R: c(
     person("Peter", "Teunis", , "p.teunis@emory.edu", role = c("aut", "cph"),
            comment = c("Author of the method and original code.",

--- a/NEWS.md
+++ b/NEWS.md
@@ -4,9 +4,9 @@
 
 * Removed the local `dispatch-explicit-review` job from `.github/workflows/claude.yml`.
   It existed to cover `@claude, please review`, a phrasing the reusable workflow's own
-  matcher missed (#230), but that matcher has since been broadened upstream in
+  pattern missed (#230), but that pattern has since been broadened upstream in
   [`d-morrison/gha#341`](https://github.com/d-morrison/gha/pull/341).
-  With both matchers live, a plain `@claude review` dispatched two paid review runs,
+  With both patterns live, a plain `@claude review` dispatched two paid review runs,
   which could review different heads because the local job had no `needs: claude`
   (closes #277, closes #276).
 * Added a project-level `Claude Code` skill, `reprexes`

--- a/NEWS.md
+++ b/NEWS.md
@@ -4,7 +4,7 @@
 
 * Removed the local `dispatch-explicit-review` job from `.github/workflows/claude.yml`.
   It existed to cover `@claude, please review`, a phrasing the reusable workflow's own
-  pattern missed (#230), but that pattern has since been broadened upstream in
+  pattern missed (#277), but that pattern has since been broadened upstream in
   [`d-morrison/gha#341`](https://github.com/d-morrison/gha/pull/341).
   With both patterns live, a plain `@claude review` dispatched two paid review runs,
   which could review different heads because the local job had no `needs: claude`

--- a/NEWS.md
+++ b/NEWS.md
@@ -2,6 +2,13 @@
 
 ## Internal
 
+* Removed the local `dispatch-explicit-review` job from `.github/workflows/claude.yml`.
+  It existed to cover `@claude, please review`, a phrasing the reusable workflow's own
+  matcher missed (#230), but that matcher has since been broadened upstream in
+  [`d-morrison/gha#341`](https://github.com/d-morrison/gha/pull/341).
+  With both matchers live, a plain `@claude review` dispatched two paid review runs,
+  which could review different heads because the local job had no `needs: claude`
+  (closes #277, closes #276).
 * Added a project-level `Claude Code` skill, `reprexes`
   (`.claude/skills/reprexes`), capturing a workflow for isolating a problem
   into a minimal reproducible example and iterating fixes on it before


### PR DESCRIPTION
Closes #277. Closes #276.

> [!IMPORTANT]
> Merge [d-morrison/gha#341](https://github.com/d-morrison/gha/pull/341) first, **and wait for gha's `@v2` tag to advance past it**. This repo pins `d-morrison/gha/.github/workflows/claude.yml@v2`, so until the tag moves, the reusable workflow still carries the narrow matcher and merging this PR would leave `@claude, please review` unhandled again — the #230 regression.

#277 chose **option 1**: broaden the matcher upstream rather than keep working around it here.

## Why this job existed, and why it can go

It was added because the reusable workflow's matcher required whitespace and nothing else between `@claude` and `review`, so `@claude, please review` was answered by the agent instead of being routed to the reviewer (#230).

gha#341 fixes that upstream. With both matchers live, the local job is not just redundant but harmful:

| Comment | reusable | local job | result |
|---|---|---|---|
| `@claude review` | match | match | **two paid review runs** |
| `@claude, please review` | (before gha#341) no match | match | one |
| `@claude can you review this?` | (before gha#341) no match | no match | none — #276 |

The double dispatch hit the plainest phrasing, not an edge case. And because the local job had no `needs: claude`, on something like `@claude review and fix the failing test` the two runs could review **different heads** — the local one firing against the pre-fix code while the reusable's fired after Claude committed.

After gha#341, the reusable workflow's matcher covers every phrasing the local job covered plus the ones neither handled, so #276 is closed by the same change rather than by fixing this regex.

## One behavior change worth naming

The deleted job carried the only author gate on its own dispatch path, `OWNER`/`MEMBER`. The reusable workflow applies `OWNER`/`MEMBER`/`COLLABORATOR` on an `@claude` mention. So the trusted set widens by `COLLABORATOR` — repository collaborators without org membership. That matches what every other `@claude` path in this repo already allows (the `claude` job above delegates to the same gate), so this removes an inconsistency rather than introducing a hole; flagging it because it is a real, if small, widening and shouldn't be discovered later.

`pr-commands.yaml` keeps its own stricter `OWNER`/`MEMBER` gate for `/document` and `/style`; nothing here touches it.

## Verification

A comment left in place of the job records why there is no local dispatch here, so the next person hitting a missed phrasing looks upstream instead of re-adding this. `NEWS.md` gains an `## Internal` entry and `DESCRIPTION` is bumped for `version-check`. YAML parses.

I could not exercise the end state on this PR: it depends on a `@v2` tag that has not moved yet, and this repo's own automatic review is disabled (#266) so `claude-code-review.yml` is dispatch-only regardless.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WcQrGoM5AfNAQLN4r4ymPg

---
_Generated by [Claude Code](https://claude.ai/code/session_01WcQrGoM5AfNAQLN4r4ymPg)_