### PR TITLE
Repoint gha reusable workflows to Morrison-Lab/gha

### DIFF
--- a/.github/workflows/bump-submodule.yml
+++ b/.github/workflows/bump-submodule.yml
@@ -14,7 +14,7 @@ jobs:
     permissions:
       contents: write
       pull-requests: write
-    uses: d-morrison/gha/.github/workflows/bump-submodule.yml@v1
+    uses: Morrison-Lab/gha/.github/workflows/bump-submodule.yml@v1
     with:
       submodule-path: .ai-config
       # remote-branch: main        # defaults to the submodule's configured branch

--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -1,4 +1,4 @@
-# Calls the reusable Claude review workflow in d-morrison/gha. The
+# Calls the reusable Claude review workflow in Morrison-Lab/gha. The
 # workflow_dispatch path lets claude.yml re-dispatch a review after an @claude
 # run pushes commits — keep this file named claude-code-review.yml.
 #
@@ -25,7 +25,7 @@ jobs:
       issues: write
       id-token: write
       actions: read
-    uses: d-morrison/gha/.github/workflows/claude-code-review.yml@v2
+    uses: Morrison-Lab/gha/.github/workflows/claude-code-review.yml@v2
     secrets:
       CLAUDE_CODE_OAUTH_TOKEN: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
     with:

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -1,4 +1,4 @@
-# Calls the reusable Claude Code workflow in d-morrison/gha. Secrets passed
+# Calls the reusable Claude Code workflow in Morrison-Lab/gha. Secrets passed
 # explicitly so the cross-repo call forwards a real token. The reusable enforces
 # the @claude mention + trusted-author gate.
 #
@@ -23,7 +23,7 @@ jobs:
       issues: write
       id-token: write
       actions: write
-    uses: d-morrison/gha/.github/workflows/claude.yml@v2
+    uses: Morrison-Lab/gha/.github/workflows/claude.yml@v2
     secrets:
       CLAUDE_CODE_OAUTH_TOKEN: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
     with:
@@ -34,7 +34,7 @@ jobs:
 
 # There is deliberately no local review-dispatch job here. One existed, to
 # cover `@claude, please review` -- a phrasing the reusable workflow's own
-# matcher missed. d-morrison/gha#341 fixed that matcher upstream, so the
+# matcher missed. Morrison-Lab/gha#341 fixed that matcher upstream, so the
 # local job became a duplicate: a plain `@claude review` matched both and
 # dispatched two paid review runs, which could review different heads since
 # the local job had no `needs: claude`. See #277 for both halves. Dispatch

--- a/.github/workflows/cleanup-pr-previews.yml
+++ b/.github/workflows/cleanup-pr-previews.yml
@@ -1,5 +1,5 @@
 # Housekeeping half of the PR-preview family, delegated to the reusable
-# cleanup-pr-previews workflow in d-morrison/gha. Periodically deletes gh-pages
+# cleanup-pr-previews workflow in Morrison-Lab/gha. Periodically deletes gh-pages
 # preview directories for PRs that are no longer open, and (compact-history)
 # orphan-squashes gh-pages to a single commit so the deleted snapshots stop
 # bloating the repo. The calling job grants contents: write so the reusable can
@@ -25,6 +25,6 @@ jobs:
     permissions:
       contents: write
       pull-requests: read
-    uses: d-morrison/gha/.github/workflows/cleanup-pr-previews.yml@v2
+    uses: Morrison-Lab/gha/.github/workflows/cleanup-pr-previews.yml@v2
     with:
       compact-history: true


### PR DESCRIPTION
The `gha` repo moved from `d-morrison/gha` to `Morrison-Lab/gha`.

GitHub Actions does **not** follow repository-rename redirects for `uses:`, so
every call in this repo was failing to resolve before any job started. This
repoints all 8 reference(s) across 4 workflow file(s). Tags and paths
are unchanged.

Direct push to the default branch was blocked by repository rules, so this is a PR.