### PR TITLE
fix: retarget the ai-config marketplace to Morrison-Lab

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,13 +1,13 @@
 {
   "extraKnownMarketplaces": {
-    "d-morrison": {
+    "Morrison-Lab": {
       "source": {
         "source": "github",
-        "repo": "d-morrison/ai-config"
+        "repo": "Morrison-Lab/ai-config"
       }
     }
   },
   "enabledPlugins": {
-    "ai-config@d-morrison": true
+    "ai-config@Morrison-Lab": true
   }
 }

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,4 +1,4 @@
 [submodule ".ai-config"]
 	path = .ai-config
-	url = https://github.com/d-morrison/ai-config.git
+	url = https://github.com/Morrison-Lab/ai-config.git
 	branch = main

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -9,7 +9,7 @@ file adds review-specific emphasis on top of that guide.
 ## ai-config submodule
 
 The `.ai-config` git submodule pins a copy of
-[`d-morrison/ai-config`](https://github.com/d-morrison/ai-config) — the
+[`Morrison-Lab/ai-config`](https://github.com/Morrison-Lab/ai-config) — the
 corpus one of this file's review guidelines cites (`shared/` fragments,
 skills, memories). A scheduled `Bump submodule` workflow
 (`.github/workflows/bump-submodule.yml`) keeps the pin fresh and opens a PR
@@ -84,7 +84,7 @@ form. Treat these as in-scope review findings, not optional nits:
   [`...`](https://adv-r.hadley.nz/functions.html?q=dot-dot#fun-dot-dot-dot)
   straight to the subfunction (documented via `@inheritDotParams`). This is
   a global standing rule from the
-  [`d-morrison/ai-config`](https://github.com/d-morrison/ai-config) corpus
+  [`Morrison-Lab/ai-config`](https://github.com/Morrison-Lab/ai-config) corpus
   (`shared/coding/reuse-docs-and-args.md`).
 
 ## Deprecation strictness

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: serodynamics
 Title: Modeling Longitudinal Antibody Responses to Infection
-Version: 0.1.0.9011
+Version: 0.1.0.9012
 Authors@R: c(
     person("Peter", "Teunis", , "p.teunis@emory.edu", role = c("aut", "cph"),
            comment = c("Author of the method and original code.",

--- a/NEWS.md
+++ b/NEWS.md
@@ -2,6 +2,14 @@
 
 ## Internal
 
+* Retargeted the ai-config Claude Code plugin marketplace to `Morrison-Lab`.
+  The corpus moved orgs and renamed the marketplace declared in its own
+  `.claude-plugin/marketplace.json`, and a plugin ref resolves by that declared
+  name, so `.claude/settings.json`'s `ai-config@d-morrison` matched nothing and
+  aborted plugin installation in cloud/web sessions opened on this repo.
+  The clone URL was never the problem, since git follows GitHub's transfer
+  redirect; only the name lookup failed.
+  `.gitmodules` and `CLAUDE.md`'s live links were retargeted alongside it.
 * Removed the local `dispatch-explicit-review` job from `.github/workflows/claude.yml`.
   It existed to cover `@claude, please review`, a phrasing the reusable workflow's own
   pattern missed (#277), but that pattern has since been broadened upstream in

--- a/NEWS.md
+++ b/NEWS.md
@@ -2,14 +2,16 @@
 
 ## Internal
 
-* Retargeted the ai-config Claude Code plugin marketplace to `Morrison-Lab`.
-  The corpus moved orgs and renamed the marketplace declared in its own
-  `.claude-plugin/marketplace.json`, and a plugin ref resolves by that declared
-  name, so `.claude/settings.json`'s `ai-config@d-morrison` matched nothing and
-  aborted plugin installation in cloud/web sessions opened on this repo.
+* Pointed the `ai-config` Claude Code plugin marketplace at `Morrison-Lab`.
+  The corpus moved to a new GitHub organization and renamed the marketplace
+  declared in its own `.claude-plugin/marketplace.json`.
+  A plugin reference resolves by that declared name, so
+  `.claude/settings.json`'s `ai-config@d-morrison` matched nothing and aborted
+  plugin installation in cloud and web sessions opened on this repo.
   The clone URL was never the problem, since git follows GitHub's transfer
   redirect; only the name lookup failed.
-  `.gitmodules` and `CLAUDE.md`'s live links were retargeted alongside it.
+  `.gitmodules` and `CLAUDE.md`'s live links now point at the new organization
+  as well.
 * Removed the local `dispatch-explicit-review` job from `.github/workflows/claude.yml`.
   It existed to cover `@claude, please review`, a phrasing the reusable workflow's own
   pattern missed (#277), but that pattern has since been broadened upstream in


### PR DESCRIPTION
## What

`ai-config` moved to the `Morrison-Lab` org and renamed the marketplace it declares in its own `.claude-plugin/marketplace.json` from `d-morrison` to `Morrison-Lab` ([ai-config#802](https://github.com/Morrison-Lab/ai-config/pull/802)). A plugin ref resolves by that **declared** name, so this repo's `.claude/settings.json` asking for `ai-config@d-morrison` matches nothing.

## Why it matters

This is the same defect that broke the `@claude` workflows repo-wide. That instance was in `Morrison-Lab/gha` and is fixed upstream ([gha#359](https://github.com/Morrison-Lab/gha/pull/359), released when `v2` was slid to `c50e847`). This PR fixes the *second* instance, in serodynamics' own settings — which the gha fix does not cover.

It affects Claude Code web/cloud sessions opened directly on this repo, which load ai-config's skills via `enabledPlugins` (as `CLAUDE.md`'s "ai-config submodule" section describes). Those sessions currently abort plugin installation with:

```
✔ Successfully added marketplace: Morrison-Lab
✘ Failed to install plugin "ai-config@d-morrison": Plugin "ai-config" not found in marketplace "d-morrison".
```

## The clone URL was never the problem

Worth stating explicitly, since it makes the bug look already-fixed: `git` and `gh` both follow GitHub's transfer redirect, so `d-morrison/ai-config.git` still clones fine and the marketplace registers itself as `Morrison-Lab` regardless of which URL fetched it. Only the **name lookup** fails. Verified against the current manifest, which declares `"name": "Morrison-Lab"` and a plugin named `ai-config` — so `ai-config@Morrison-Lab` is the valid ref.

## Changes

- `.claude/settings.json` — marketplace key, `repo`, and the `enabledPlugins` ref retargeted to `Morrison-Lab`. **This is the functional fix.**
- `.gitmodules` — submodule URL retargeted. Cosmetic (the redirect works), included for consistency with the org move, which [#279](https://github.com/UCD-SERG/serodynamics/pull/279) started for the gha workflow refs.
- `CLAUDE.md` — the two *live* pointers to the corpus retargeted.

`NEWS.md` is deliberately left alone: its `d-morrison/ai-config` mentions are historical changelog records of what happened at the time, not live references.

## Note for reviewers with an existing clone

The `.gitmodules` URL change needs a one-time `git submodule sync` in existing local clones. Fresh clones and CI are unaffected.


---
_Generated by [Claude Code](https://claude.ai/code/session_012PKotEhi2qeEQ1kZwuFES8)_