### PR TITLE
ci: disable the @claude agent; allow reviews on request only

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -1,24 +1,119 @@
-# Calls the reusable Claude review workflow in Morrison-Lab/gha. The
-# workflow_dispatch path lets claude.yml re-dispatch a review after an @claude
-# run pushes commits — keep this file named claude-code-review.yml.
+# On-demand Claude Code review of pull requests -- caller stub for the central
+# Morrison-Lab/gha reusable workflow.
+#
+# Reviews run ONLY on request: comment `/review` on a PR. Automatic review on
+# PR activity is disabled (see #266), and so is the @claude agent
+# (claude.yml), so this `/review` comment path is the only way a review runs.
+# It is a slash command rather than an `@claude ...` mention on purpose: the
+# mention path lives in claude.yml, which is switched off.
+#
+# The workflow_dispatch path is what dispatch-on-comment re-enters, and is
+# also how claude.yml re-dispatches a review after an @claude run pushes
+# commits -- keep this file named claude-code-review.yml.
+#
+# NOTE for whoever re-enables or audits this: if `review / require-review` (or
+# `review / claude-review`) is configured as a REQUIRED status check in this
+# repo's branch protection, it will not report on ordinary PRs, and those PRs
+# will sit blocked waiting for a status that never arrives. Keep it out of the
+# required-checks list while automatic review is off.
 #
 # Pinned to the @v2 moving major tag.
 name: Claude Code Review
 
 on:
-  # Automatic review on PR events is temporarily disabled (see #266).
+  # Automatic review on PR events is disabled (see #266).
   # Re-enable by uncommenting the `pull_request:` trigger below.
   # pull_request:
   #   types: [opened, synchronize, ready_for_review, reopened]
+  issue_comment:
+    types: [created]
   workflow_dispatch:
     inputs:
       pr_number:
         description: 'Pull request number to review'
         required: true
-        type: number
+        # String rather than number: the reusable workflow's `pr-number` input
+        # is a string, and `gh workflow run -f` sends one.
+        type: string
 
 jobs:
+  # `/review` at the start of a PR comment (from an OWNER/MEMBER/COLLABORATOR)
+  # dispatches an on-demand review of that PR. This re-enters the
+  # workflow_dispatch path below via `gh workflow run` (the reusable
+  # workflow's jobs skip a raw issue_comment run), so it needs this file on
+  # the default branch first.
+  dispatch-on-comment:
+    if: >-
+      github.event_name == 'issue_comment' &&
+      github.event.issue.pull_request &&
+      startsWith(github.event.comment.body, '/review') &&
+      contains(fromJSON('["OWNER","MEMBER","COLLABORATOR"]'), github.event.comment.author_association)
+    runs-on: ubuntu-latest
+    permissions:
+      actions: write        # dispatch this workflow via `gh workflow run`
+      issues: write         # acknowledge the /review comment
+    steps:
+      - name: Parse this workflow's ref
+        id: this-wf
+        uses: Morrison-Lab/gha/.github/actions/parse-workflow-ref@v2
+        with:
+          workflow-ref: ${{ github.workflow_ref }}
+
+      - name: Dispatch a review for the commented PR
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REPO: ${{ github.repository }}
+          PR_NUMBER: ${{ github.event.issue.number }}
+          WF_PATH: ${{ steps.this-wf.outputs.path }}
+          # Passed via env (not inlined) so the comment body is a shell value,
+          # never interpreted as script -- avoids injection.
+          COMMENT_BODY: ${{ github.event.comment.body }}
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+        run: |
+          set -euo pipefail
+          # The job-level `if:` only does a cheap startsWith('/review')
+          # pre-filter; GitHub Actions expressions can't reliably tell
+          # '/review' from '/reviewer' or handle a newline/tab after the
+          # command. Enforce the real match here: the body must begin with a
+          # standalone '/review' token, followed by whitespace or end-of-string.
+          if [[ ! "$COMMENT_BODY" =~ ^/review([[:space:]]|$) ]]; then
+            echo "Comment does not start with a standalone '/review' command; skipping dispatch."
+            exit 0
+          fi
+          # This workflow's filename, so the dispatch resolves whatever you
+          # name the file -- WF_PATH is the .github/workflows/<file> portion.
+          WF_FILE=$(basename "$WF_PATH")
+          # This job never checks out the repo, so the PR's head branch has to
+          # be looked up explicitly. --ref pins the dispatched run's check-runs
+          # to that branch instead of the default branch workflow_dispatch
+          # falls back to when no ref is given -- without it, the review
+          # check-run lands on the wrong commit.
+          PR_JSON=$(gh api "repos/$REPO/pulls/$PR_NUMBER")
+          PR_BRANCH=$(jq -r '.head.ref' <<< "$PR_JSON")
+          PR_HEAD_REPO=$(jq -r '.head.repo.full_name' <<< "$PR_JSON")
+          echo "Dispatching $WF_FILE to review PR #$PR_NUMBER ($PR_BRANCH) (/review comment)."
+          # A fork PR's head branch only exists in the fork, not in $REPO, so
+          # --ref would fail to resolve there. Fall back to no --ref for fork
+          # PRs; the resulting check-run mis-attributes to the default branch
+          # (the no-ref behavior), the lesser problem.
+          REF_ARGS=(--ref "$PR_BRANCH")
+          if [ "$PR_HEAD_REPO" != "$REPO" ]; then
+            echo "::notice::PR #$PR_NUMBER is from a fork ($PR_HEAD_REPO); dispatching $WF_FILE without --ref."
+            REF_ARGS=()
+          fi
+          # --repo is required: this job doesn't check out the repo, so gh has
+          # no git remote to infer it from.
+          gh workflow run "$WF_FILE" --repo "$REPO" "${REF_ARGS[@]}" -f pr_number="$PR_NUMBER"
+          gh issue comment "$PR_NUMBER" --repo "$REPO" \
+            --body ":mag: \`/review\` received -- dispatched a Claude review of this PR (see the [dispatch run]($RUN_URL)). The review posts as its own comment when it finishes." \
+            || echo "::warning::Could not acknowledge the /review comment."
+
   review:
+    # workflow_dispatch only while the pull_request trigger is off; the
+    # issue_comment path is handled by dispatch-on-comment above (which
+    # re-enters via workflow_dispatch). Written as `!= 'issue_comment'` so
+    # re-enabling the pull_request trigger needs no change here.
+    if: github.event_name != 'issue_comment'
     permissions:
       contents: read
       pull-requests: write

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -3,20 +3,40 @@
 # the @claude mention + trusted-author gate.
 #
 # Pinned to the @v2 moving major tag.
+#
+# ---------------------------------------------------------------------------
+# DISABLED. The @claude agent is switched off in this repo for now; only
+# reviews are allowed, and only on request (comment `/review` on a PR -- see
+# claude-code-review.yml).
+#
+# Two mechanisms, because either alone is insufficient:
+#   - The reactive triggers below are commented out, so no comment, issue, or
+#     review event reaches this workflow. GitHub rejects a workflow file with
+#     no `on:` key at all, so `workflow_dispatch:` remains as a placeholder.
+#   - `if: false` on the job, because the reusable workflow runs UNATTENDED on
+#     workflow_dispatch (its own gate deliberately exempts that event, since a
+#     manual dispatch already requires Actions write access). Without this,
+#     the placeholder trigger would leave the agent manually runnable.
+#
+# To re-enable: uncomment the trigger block below and delete the job's
+# `if: false`. Nothing else needs to change.
+# ---------------------------------------------------------------------------
 name: Claude Code
 
 on:
-  issue_comment:
-    types: [created]
-  pull_request_review_comment:
-    types: [created]
-  issues:
-    types: [opened, assigned]
-  pull_request_review:
-    types: [submitted]
+  # issue_comment:
+  #   types: [created]
+  # pull_request_review_comment:
+  #   types: [created]
+  # issues:
+  #   types: [opened, assigned]
+  # pull_request_review:
+  #   types: [submitted]
+  workflow_dispatch:
 
 jobs:
   claude:
+    if: false  # agent disabled; see the header comment
     permissions:
       contents: write
       pull-requests: write
@@ -39,4 +59,5 @@ jobs:
 # dispatched two paid review runs, which could review different heads since
 # the local job had no `needs: claude`. See #277 for both halves. Dispatch
 # now happens only in the reusable workflow, which applies its own
-# trusted-author gate.
+# trusted-author gate -- and while this workflow is disabled, only via the
+# `/review` comment path in claude-code-review.yml.

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: serodynamics
 Title: Modeling Longitudinal Antibody Responses to Infection
-Version: 0.1.0.9012
+Version: 0.1.0.9013
 Authors@R: c(
     person("Peter", "Teunis", , "p.teunis@emory.edu", role = c("aut", "cph"),
            comment = c("Author of the method and original code.",

--- a/NEWS.md
+++ b/NEWS.md
@@ -2,6 +2,16 @@
 
 ## Internal
 
+* Disabled the `@claude` agent bot.
+  `.github/workflows/claude.yml`'s reactive triggers are commented out and its
+  job carries `if: false`, so no comment, issue, or review event invokes the
+  agent, and neither does a manual dispatch (the reusable workflow runs
+  unattended on `workflow_dispatch` by design).
+  Reviews are the only Claude capability left, and they run on request only:
+  comment `/review` on a pull request.
+  That path is new here -- `claude-code-review.yml` gained an `issue_comment`
+  trigger and a `dispatch-on-comment` job, since the `@claude review` mention
+  it previously relied on went away with the agent.
 * Pointed the `ai-config` Claude Code plugin marketplace at `Morrison-Lab`.
   The corpus moved to a new GitHub organization and renamed the marketplace
   declared in its own `.claude-plugin/marketplace.json`.


### PR DESCRIPTION
Switches off the `@claude` agent bot in this repo. Reviews are the only Claude capability left, and they run **on request only**: a collaborator comments `/review` on a pull request.

## What changed

**`.github/workflows/claude.yml` -- agent disabled.**

The file keeps all of its configuration (the `apt-packages: jags` input and so on) but stops running. Two mechanisms, because either alone is insufficient:

- The reactive triggers (`issue_comment`, `pull_request_review_comment`, `issues`, `pull_request_review`) are commented out, so no event reaches the workflow. GitHub rejects a workflow file with no `on:` key at all, so a `workflow_dispatch:` placeholder has to stay.
- `if: false` on the job. The reusable workflow **runs unattended on `workflow_dispatch`** -- its own gate deliberately exempts that event ([`claude.yml` L232-244](https://github.com/Morrison-Lab/gha/blob/v2/.github/workflows/claude.yml)), on the reasoning that dispatching already requires Actions write access. Without `if: false`, the placeholder trigger would leave the agent manually runnable, which is not "disabled".

Re-enabling is uncommenting the trigger block and deleting `if: false`.

**`.github/workflows/claude-code-review.yml` -- gained the `/review` comment path.**

This is the part that is genuinely new here rather than a removal. Automatic review on PR activity has been off since #266, so the *only* way a review started in this repo was an `@claude review` mention, which `claude.yml` dispatched. Disabling the agent removes that path, which would have left no way to run a review at all.

So the stub picks up the `/review` path from [gha's own example stub](https://github.com/Morrison-Lab/gha/blob/v2/examples/claude-code-review.yml): an `issue_comment` trigger plus a `dispatch-on-comment` job gated on `OWNER`/`MEMBER`/`COLLABORATOR`, which re-enters the existing `workflow_dispatch` path via `gh workflow run`. A slash command rather than a mention, on purpose -- the mention path lives in `claude.yml`, which is off.

Two details carried over from the upstream example:

- The dispatch looks up the PR's head branch and passes `--ref`, so the review check-run lands on the PR's own commit instead of the default branch that `workflow_dispatch` otherwise falls back to. Fork PRs fall back to no `--ref`, since their head branch does not exist in this repo.
- The job-level `if:` is only a cheap `startsWith('/review')` pre-filter; the step re-checks with a regex, because Actions expressions cannot distinguish `/review` from `/reviewer`. The comment body is passed via `env:` rather than inlined, so it is never interpreted as script.

The `pr_number` dispatch input changes from `number` to `string`, matching the reusable workflow's own `pr-number` input type and what `gh workflow run -f` sends.

## Heads-up before merging

If `review / require-review` (or `review / claude-review`) is a **required status check** in this repo's branch protection, it will not report on ordinary PRs, and those PRs will sit blocked waiting for a status that never arrives. It should stay off the required-checks list while automatic review is off. I could not read branch protection from this session, so please confirm. This is noted in the workflow's own header too.

## Verification

- All four touched/related workflow files parse as YAML; triggers and job gates read back as intended (`claude.yml`: `workflow_dispatch` only, job `if: false`; `claude-code-review.yml`: `issue_comment` + `workflow_dispatch`, no `pull_request`).
- The embedded shell in `dispatch-on-comment` passes `bash -n`.
- The 140 added lines carry no em-dashes, en-dashes, curly quotes, or other banned non-ASCII punctuation.

Not verified: the `/review` path itself cannot be exercised until this file is on the default branch, since `gh workflow run` resolves the workflow there.

Refs #266.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BSYXLnUqVqDXLZtPpFSaQM

---
_Generated by [Claude Code](https://claude.ai/code/session_01BSYXLnUqVqDXLZtPpFSaQM)_