### PR TITLE
No default priors

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -78,5 +78,4 @@ Depends:
     R (>= 4.1.0)
 LazyData: true
 VignetteBuilder: knitr, quarto
-Config/roxygen2/version: 8.0.0
-RoxygenNote: 8.0.0
+Config/roxygen2/version: 8.1.0

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: serodynamics
 Title: Modeling Longitudinal Antibody Responses to Infection
-Version: 0.1.0.9013
+Version: 0.1.0.9014
 Authors@R: c(
     person("Peter", "Teunis", , "p.teunis@emory.edu", role = c("aut", "cph"),
            comment = c("Author of the method and original code.",

--- a/NAMESPACE
+++ b/NAMESPACE
@@ -23,30 +23,40 @@ export(serodynamics_example)
 export(sim_case_data)
 export(sim_n_obs)
 export(summarize_posterior)
-importFrom(dplyr,.data)
-importFrom(dplyr,all_of)
-importFrom(dplyr,filter)
-importFrom(dplyr,mutate)
-importFrom(dplyr,n)
-importFrom(dplyr,reframe)
-importFrom(dplyr,rename)
-importFrom(dplyr,rowwise)
-importFrom(dplyr,select)
-importFrom(dplyr,ungroup)
+importFrom(dplyr,
+  .data,
+  all_of,
+  filter,
+  mutate,
+  n,
+  reframe,
+  rename,
+  rowwise,
+  select,
+  ungroup
+)
 importFrom(ggmcmc,ggs)
-importFrom(ggplot2,autoplot)
-importFrom(ggplot2,theme_bw)
-importFrom(ggplot2,vars)
-importFrom(rlang,.data)
-importFrom(rlang,.env)
+importFrom(ggplot2,
+  autoplot,
+  theme_bw,
+  vars
+)
+importFrom(rlang,
+  .data,
+  .env
+)
 importFrom(runjags,run.jags)
-importFrom(serocalculator,get_biomarker_levels)
-importFrom(serocalculator,get_biomarker_names)
-importFrom(serocalculator,get_biomarker_names_var)
-importFrom(serocalculator,get_values)
-importFrom(serocalculator,ids)
-importFrom(serocalculator,ids_varname)
-importFrom(stats,complete.cases)
-importFrom(stats,quantile)
+importFrom(serocalculator,
+  get_biomarker_levels,
+  get_biomarker_names,
+  get_biomarker_names_var,
+  get_values,
+  ids,
+  ids_varname
+)
+importFrom(stats,
+  complete.cases,
+  quantile
+)
 importFrom(tidyr,pivot_wider)
 importFrom(utils,read.csv)

--- a/NEWS.md
+++ b/NEWS.md
@@ -2,6 +2,8 @@
 
 ## Internal
 
+* Took away default priors from `run_serodynamics()`. Users must manually 
+  specify priors now in order to run function.
 * Disabled the `@claude` agent bot.
   `.github/workflows/claude.yml`'s reactive triggers are commented out and its
   job carries `if: false`, so no comment, issue, or review event invokes the

--- a/R/prep_priors.R
+++ b/R/prep_priors.R
@@ -8,27 +8,24 @@
 #' @param mu_hyp_param A [numeric] [vector] of 5 values representing the prior
 #' mean for the population level parameters
 #' parameters (y0, y1, t1, r, alpha) for each biomarker.
-#' If specified, must be 5 values long, representing the following parameters:
-#'    - y0 = baseline antibody concentration (default = 1.0)
-#'    - y1 = peak antibody concentration (default = 7.0)
-#'    - t1 = time to peak (default = 1.0)
-#'    - r = shape parameter (default = -4.0)
-#'    - alpha = decay rate (default = -1.0)
+#' Must be 5 values long, representing the following parameters:
+#'    - y0 = baseline antibody concentration
+#'    - y1 = peak antibody concentration
+#'    - t1 = time to peak
+#'    - r = shape parameter
+#'    - alpha = decay rate
 #' @param prec_hyp_param A [numeric] [vector] of 5 values corresponding to
 #' hyperprior diagonal entries for the precision matrix (i.e. inverse variance)
 #' representing prior covariance of uncertainty around `mu_hyp_param`.
-#' If specified, must be 5 values long:
-#'    - defaults: y0 = 1.0, y1 = 0.00001, t1 = 1.0, r = 0.001, alpha = 1.0
+#' Must be 5 values long corresponding to the 5 estimated parameters.
 #' @param omega_param A [numeric] [vector] of 5 values corresponding to the
 #' diagonal entries representing the Wishart hyperprior
 #' distributions of `prec_hyp_param`, describing how much we expect parameters
 #' to vary between individuals.
-#' If specified, must be 5 values long:
-#'    - defaults: y0 = 1.0, y1 = 50.0, t1 = 1.0, r = 10.0, alpha = 1.0
+#' Must be 5 values long corresponding to the 5 estimated parameters.
 #' @param wishdf_param An [integer] [vector] of 1 value specifying the degrees
 #' of freedom for the Wishart hyperprior distribution of `prec_hyp_param`.
-#' If specified, must be 1 value long.
-#'    - default = 20.0
+#' Must be 1 value long.
 #'    - The value of `wishdf_param` controls how informative the Wishart prior
 #'      is. Higher values lead to tighter priors on individual variation.
 #'      Lower values (e.g., 5–10) make the prior more weakly informative,
@@ -36,8 +33,7 @@
 #' @param prec_logy_hyp_param A [numeric] [vector] of 2 values corresponding to
 #' hyperprior diagonal entries on the log-scale for the precision matrix
 #' (i.e. inverse variance) representing prior beliefs of individual variation.
-#' If specified, must be 2 values long:
-#'    - defaults = 4.0, 1.0
+#' Must be 2 values long.
 #'
 #' @returns A "curve_params_priors" object 
 #' (a subclass of [list] with the inputs to `prep_priors()` attached 
@@ -65,11 +61,11 @@
 #' @example inst/examples/examples-prep_priors.R
 
 prep_priors <- function(max_antigens,
-                        mu_hyp_param = c(1.0, 7.0, 1.0, -4.0, -1.0),
-                        prec_hyp_param = c(1.0, 0.00001, 1.0, 0.001, 1.0),
-                        omega_param = c(1.0, 50.0, 1.0, 10.0, 1.0),
-                        wishdf_param = 20,
-                        prec_logy_hyp_param = c(4.0, 1.0)) {
+                        mu_hyp_param = NULL,
+                        prec_hyp_param = NULL,
+                        omega_param = NULL,
+                        wishdf_param = NULL,
+                        prec_logy_hyp_param = NULL) {
 
   # Ensuring the length of specified priors is correct.
   # mu_hyp_param

--- a/R/run_serodynamics.R
+++ b/R/run_serodynamics.R
@@ -5,7 +5,9 @@
 #'  [runjags::run.jags()] as an MCMC
 #'  Bayesian model to estimate antibody dynamic curve parameters.
 #'  The [rjags::jags.model()] models seroresponse dynamics to an
-#'  infection. The antibody dynamic curve includes the following parameters:
+#'  infection. Priors are required for modeling and must be specified prior to
+#'  running `run_serodynamics`. The antibody dynamic curve includes the 
+#'  following parameters:
 #'  - y0 = baseline antibody concentration
 #'  - y1 = peak antibody concentration
 #'  - t1 = time to peak

--- a/man/prep_priors.Rd
+++ b/man/prep_priors.Rd
@@ -6,11 +6,11 @@
 \usage{
 prep_priors(
   max_antigens,
-  mu_hyp_param = c(1, 7, 1, -4, -1),
-  prec_hyp_param = c(1, 1e-05, 1, 0.001, 1),
-  omega_param = c(1, 50, 1, 10, 1),
-  wishdf_param = 20,
-  prec_logy_hyp_param = c(4, 1)
+  mu_hyp_param = NULL,
+  prec_hyp_param = NULL,
+  omega_param = NULL,
+  wishdf_param = NULL,
+  prec_logy_hyp_param = NULL
 )
 }
 \arguments{
@@ -20,37 +20,30 @@ antigen-isotypes (biomarkers) will be modeled.}
 \item{mu_hyp_param}{A \link{numeric} \link{vector} of 5 values representing the prior
 mean for the population level parameters
 parameters (y0, y1, t1, r, alpha) for each biomarker.
-If specified, must be 5 values long, representing the following parameters:
+Must be 5 values long, representing the following parameters:
 \itemize{
-\item y0 = baseline antibody concentration (default = 1.0)
-\item y1 = peak antibody concentration (default = 7.0)
-\item t1 = time to peak (default = 1.0)
-\item r = shape parameter (default = -4.0)
-\item alpha = decay rate (default = -1.0)
+\item y0 = baseline antibody concentration
+\item y1 = peak antibody concentration
+\item t1 = time to peak
+\item r = shape parameter
+\item alpha = decay rate
 }}
 
 \item{prec_hyp_param}{A \link{numeric} \link{vector} of 5 values corresponding to
 hyperprior diagonal entries for the precision matrix (i.e. inverse variance)
 representing prior covariance of uncertainty around \code{mu_hyp_param}.
-If specified, must be 5 values long:
-\itemize{
-\item defaults: y0 = 1.0, y1 = 0.00001, t1 = 1.0, r = 0.001, alpha = 1.0
-}}
+Must be 5 values long corresponding to the 5 estimated parameters.}
 
 \item{omega_param}{A \link{numeric} \link{vector} of 5 values corresponding to the
 diagonal entries representing the Wishart hyperprior
 distributions of \code{prec_hyp_param}, describing how much we expect parameters
 to vary between individuals.
-If specified, must be 5 values long:
-\itemize{
-\item defaults: y0 = 1.0, y1 = 50.0, t1 = 1.0, r = 10.0, alpha = 1.0
-}}
+Must be 5 values long corresponding to the 5 estimated parameters.}
 
 \item{wishdf_param}{An \link{integer} \link{vector} of 1 value specifying the degrees
 of freedom for the Wishart hyperprior distribution of \code{prec_hyp_param}.
-If specified, must be 1 value long.
+Must be 1 value long.
 \itemize{
-\item default = 20.0
 \item The value of \code{wishdf_param} controls how informative the Wishart prior
 is. Higher values lead to tighter priors on individual variation.
 Lower values (e.g., 5–10) make the prior more weakly informative,
@@ -60,10 +53,7 @@ which can help improve convergence if the model is over-regularized.
 \item{prec_logy_hyp_param}{A \link{numeric} \link{vector} of 2 values corresponding to
 hyperprior diagonal entries on the log-scale for the precision matrix
 (i.e. inverse variance) representing prior beliefs of individual variation.
-If specified, must be 2 values long:
-\itemize{
-\item defaults = 4.0, 1.0
-}}
+Must be 2 values long.}
 }
 \value{
 A "curve_params_priors" object

--- a/man/run_serodynamics.Rd
+++ b/man/run_serodynamics.Rd
@@ -80,34 +80,27 @@ antigen-isotypes (biomarkers) will be modeled.}
     \item{\code{mu_hyp_param}}{A \link{numeric} \link{vector} of 5 values representing the prior
 mean for the population level parameters
 parameters (y0, y1, t1, r, alpha) for each biomarker.
-If specified, must be 5 values long, representing the following parameters:
+Must be 5 values long, representing the following parameters:
 \itemize{
-\item y0 = baseline antibody concentration (default = 1.0)
-\item y1 = peak antibody concentration (default = 7.0)
-\item t1 = time to peak (default = 1.0)
-\item r = shape parameter (default = -4.0)
-\item alpha = decay rate (default = -1.0)
+\item y0 = baseline antibody concentration
+\item y1 = peak antibody concentration
+\item t1 = time to peak
+\item r = shape parameter
+\item alpha = decay rate
 }}
     \item{\code{prec_hyp_param}}{A \link{numeric} \link{vector} of 5 values corresponding to
 hyperprior diagonal entries for the precision matrix (i.e. inverse variance)
 representing prior covariance of uncertainty around \code{mu_hyp_param}.
-If specified, must be 5 values long:
-\itemize{
-\item defaults: y0 = 1.0, y1 = 0.00001, t1 = 1.0, r = 0.001, alpha = 1.0
-}}
+Must be 5 values long corresponding to the 5 estimated parameters.}
     \item{\code{omega_param}}{A \link{numeric} \link{vector} of 5 values corresponding to the
 diagonal entries representing the Wishart hyperprior
 distributions of \code{prec_hyp_param}, describing how much we expect parameters
 to vary between individuals.
-If specified, must be 5 values long:
-\itemize{
-\item defaults: y0 = 1.0, y1 = 50.0, t1 = 1.0, r = 10.0, alpha = 1.0
-}}
+Must be 5 values long corresponding to the 5 estimated parameters.}
     \item{\code{wishdf_param}}{An \link{integer} \link{vector} of 1 value specifying the degrees
 of freedom for the Wishart hyperprior distribution of \code{prec_hyp_param}.
-If specified, must be 1 value long.
+Must be 1 value long.
 \itemize{
-\item default = 20.0
 \item The value of \code{wishdf_param} controls how informative the Wishart prior
 is. Higher values lead to tighter priors on individual variation.
 Lower values (e.g., 5–10) make the prior more weakly informative,
@@ -116,10 +109,7 @@ which can help improve convergence if the model is over-regularized.
     \item{\code{prec_logy_hyp_param}}{A \link{numeric} \link{vector} of 2 values corresponding to
 hyperprior diagonal entries on the log-scale for the precision matrix
 (i.e. inverse variance) representing prior beliefs of individual variation.
-If specified, must be 2 values long:
-\itemize{
-\item defaults = 4.0, 1.0
-}}
+Must be 2 values long.}
   }}
 }
 \value{
@@ -192,7 +182,9 @@ for all observations.
 \code{\link[runjags:run.jags]{runjags::run.jags()}} as an MCMC
 Bayesian model to estimate antibody dynamic curve parameters.
 The \code{\link[rjags:jags.model]{rjags::jags.model()}} models seroresponse dynamics to an
-infection. The antibody dynamic curve includes the following parameters:
+infection. Priors are required for modeling and must be specified prior to
+running \code{run_serodynamics}. The antibody dynamic curve includes the
+following parameters:
 \itemize{
 \item y0 = baseline antibody concentration
 \item y1 = peak antibody concentration

--- a/tests/testthat/test-run_serodynamics.R
+++ b/tests/testthat/test-run_serodynamics.R
@@ -27,7 +27,12 @@ test_that(
       nmc = 10,
       niter = 10, # Number of iterations
       strat = "strat", # Variable to be stratified
-      with_pop_params = TRUE
+      with_pop_params = TRUE,
+      mu_hyp_param = c(1.0, 7.0, 1.0, -4.0, -1.0),
+      prec_hyp_param = c(1.0, 0.00001, 1.0, 0.001, 1.0),
+      omega_param = c(1.0, 50.0, 1.0, 10.0, 1.0),
+      wishdf_param = 20,
+      prec_logy_hyp_param = c(4.0, 1.0)
     ) |>
       suppressWarnings()
 
@@ -95,7 +100,12 @@ test_that(
       strat = "bldculres", # Variable to be stratified by
       with_post = TRUE,
       with_pop_params = TRUE,
-      preclogy_per_iso = TRUE
+      preclogy_per_iso = TRUE,
+      mu_hyp_param = c(1.0, 7.0, 1.0, -4.0, -1.0),
+      prec_hyp_param = c(1.0, 0.00001, 1.0, 0.001, 1.0),
+      omega_param = c(1.0, 50.0, 1.0, 10.0, 1.0),
+      wishdf_param = 20,
+      prec_logy_hyp_param = c(4.0, 1.0)
     ) |>
       suppressWarnings()
 
@@ -204,7 +214,12 @@ test_that(
       strat = "bldculres", # Variable to be stratified by
       with_post = TRUE,
       with_pop_params = TRUE,
-      preclogy_per_iso = TRUE
+      preclogy_per_iso = TRUE,
+      mu_hyp_param = c(1.0, 7.0, 1.0, -4.0, -1.0),
+      prec_hyp_param = c(1.0, 0.00001, 1.0, 0.001, 1.0),
+      omega_param = c(1.0, 50.0, 1.0, 10.0, 1.0),
+      wishdf_param = 20,
+      prec_logy_hyp_param = c(4.0, 1.0)
     ) |>
       suppressWarnings()
 


### PR DESCRIPTION
Taking away default priors and forcing users to input their priors manually. Changing documentation accordingly. Priors are now listed as NULL in the input for prep_priors().