### PR TITLE
ci: accept `@claude review` again, and reply instead of going silent

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -1,11 +1,24 @@
 # On-demand Claude Code review of pull requests -- caller stub for the central
 # Morrison-Lab/gha reusable workflow.
 #
-# Reviews run ONLY on request: comment `/review` on a PR. Automatic review on
-# PR activity is disabled (see #266), and so is the @claude agent
-# (claude.yml), so this `/review` comment path is the only way a review runs.
-# It is a slash command rather than an `@claude ...` mention on purpose: the
-# mention path lives in claude.yml, which is switched off.
+# Reviews run ONLY on request: comment either `/review` or `@claude review` on
+# a PR. Automatic review on PR activity is disabled (see #266), and so is the
+# @claude agent (claude.yml), so this comment path is the only way a review
+# runs.
+#
+# Both spellings are accepted because only one of them was, and it was the one
+# nobody types. #282 moved review dispatch here behind `/review` alone,
+# reasoning that the mention form belonged to claude.yml -- but claude.yml had
+# just been switched off, so `@claude review` stopped doing anything at all.
+# Every one of the three review requests made in the following twelve days used
+# the mention form and was silently skipped, and `/review` was never typed once
+# (see #285).
+#
+# !! If you re-enable claude.yml, DELETE the mention path below. !!
+# The reusable claude.yml runs its own review matcher, so an `@claude review`
+# would then match both it and this job and dispatch two paid review runs --
+# against possibly different heads, since neither waits for the other. That is
+# #277, which is why upstream's stub is `/review`-only.
 #
 # The workflow_dispatch path is what dispatch-on-comment re-enters, and is
 # also how claude.yml re-dispatches a review after an @claude run pushes
@@ -37,16 +50,33 @@ on:
         type: string
 
 jobs:
-  # `/review` at the start of a PR comment (from an OWNER/MEMBER/COLLABORATOR)
-  # dispatches an on-demand review of that PR. This re-enters the
-  # workflow_dispatch path below via `gh workflow run` (the reusable
-  # workflow's jobs skip a raw issue_comment run), so it needs this file on
-  # the default branch first.
+  # A `/review` command, or an `@claude review` mention, from an
+  # OWNER/MEMBER/COLLABORATOR dispatches an on-demand review of that PR. This
+  # re-enters the workflow_dispatch path below via `gh workflow run` (the
+  # reusable workflow's jobs skip a raw issue_comment run), so it needs this
+  # file on the default branch first.
+  #
+  # The `if:` is only a cheap pre-filter -- a GitHub Actions expression cannot
+  # tell `@claude review` from `@claude, please fix the tests`. It admits any
+  # `@claude` mention and lets the steps decide, so the job also gets to REPLY
+  # to a mention it declines, rather than leaving the commenter with the same
+  # silence #285 was about.
+  #
+  # Bot comments are excluded outright. The author_association allowlist below
+  # already covers them (github-actions[bot] posts as CONTRIBUTOR here), but
+  # this job's own replies quote `@claude review` back to the thread, so a
+  # single hole in that allowlist would be a comment loop rather than a stray
+  # run. Two independent guards is cheap insurance against an expensive
+  # failure.
   dispatch-on-comment:
     if: >-
       github.event_name == 'issue_comment' &&
       github.event.issue.pull_request &&
-      startsWith(github.event.comment.body, '/review') &&
+      github.event.comment.user.type != 'Bot' &&
+      (
+        startsWith(github.event.comment.body, '/review') ||
+        contains(github.event.comment.body, '@claude')
+      ) &&
       contains(fromJSON('["OWNER","MEMBER","COLLABORATOR"]'), github.event.comment.author_association)
     runs-on: ubuntu-latest
     permissions:
@@ -59,6 +89,40 @@ jobs:
         with:
           workflow-ref: ${{ github.workflow_ref }}
 
+      # Decides whether an `@claude ...` mention is a REVIEW request as opposed
+      # to an agent task ("@claude, please fix the failing test"). Uses gha's
+      # canonical matcher rather than a regex of our own: it already knows the
+      # accepted phrasings (`@claude review`, `@claude, please review`,
+      # `@claude review this`), and it strips code spans and blockquotes first,
+      # so a comment that merely quotes the trigger while writing about it does
+      # not fire one.
+      #
+      # `continue-on-error` so a matcher failure degrades to "not a review"
+      # rather than reddening the job; the `/review` command path below does
+      # not depend on this step at all.
+      - name: Is this comment a review request?
+        id: review-request
+        continue-on-error: true
+        uses: Morrison-Lab/gha/.github/actions/detect-review-request@v2
+        with:
+          comment-body: ${{ github.event.comment.body }}
+
+      # Only reached when the body mentions @claude and is NOT a review request.
+      # Distinguishes a mention genuinely addressed to the bot from one quoted
+      # in prose or a code block ("as @claude said earlier"), so the
+      # agent-is-disabled reply below doesn't fire on every passing reference.
+      # Its bias is deliberately the opposite of the review matcher's: a missed
+      # reply is worse than a redundant one, so an empty result -- the step
+      # errored -- falls back to the raw `contains()` verdict the job gate
+      # already made, and replies.
+      - name: Is this a mention actually addressed to the bot?
+        id: bot-mention
+        continue-on-error: true
+        if: steps.review-request.outputs.match != 'true'
+        uses: Morrison-Lab/gha/.github/actions/detect-bot-mention@v2
+        with:
+          comment-body: ${{ github.event.comment.body }}
+
       - name: Dispatch a review for the commented PR
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -68,16 +132,43 @@ jobs:
           # Passed via env (not inlined) so the comment body is a shell value,
           # never interpreted as script -- avoids injection.
           COMMENT_BODY: ${{ github.event.comment.body }}
+          # 'true' only when the matcher above ran AND classified the body as a
+          # review request; empty if the step errored out.
+          MENTION_IS_REVIEW: ${{ steps.review-request.outputs.match }}
+          # 'false' only when the matcher positively ruled the mention out;
+          # empty means it didn't run or errored, which is treated as genuine.
+          MENTION_IS_GENUINE: ${{ steps.bot-mention.outputs.match }}
           RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
         run: |
           set -euo pipefail
-          # The job-level `if:` only does a cheap startsWith('/review')
-          # pre-filter; GitHub Actions expressions can't reliably tell
-          # '/review' from '/reviewer' or handle a newline/tab after the
-          # command. Enforce the real match here: the body must begin with a
-          # standalone '/review' token, followed by whitespace or end-of-string.
-          if [[ ! "$COMMENT_BODY" =~ ^/review([[:space:]]|$) ]]; then
-            echo "Comment does not start with a standalone '/review' command; skipping dispatch."
+          # Two ways to ask for a review, decided here rather than in the
+          # job-level `if:` -- a GitHub Actions expression can't tell '/review'
+          # from '/reviewer', can't handle a newline/tab after the command, and
+          # can't tell a review mention from an agent task.
+          #
+          # 1. '/review' as a standalone leading token (whitespace or EOS after
+          #    it), which is what the pre-filter's startsWith approximates.
+          TRIGGER=""
+          if [[ "$COMMENT_BODY" =~ ^/review([[:space:]]|$) ]]; then
+            TRIGGER="/review"
+          # 2. An '@claude review' mention, per the matcher step above.
+          elif [ "$MENTION_IS_REVIEW" = "true" ]; then
+            TRIGGER="@claude review"
+          fi
+
+          if [ -z "$TRIGGER" ]; then
+            # Not a review request. Say so when someone addressed the agent,
+            # because the agent is switched off here and a silent skip is
+            # indistinguishable from a broken bot -- which is exactly how #285
+            # went unnoticed for twelve days.
+            if [ "$MENTION_IS_GENUINE" != "false" ] && [[ "$COMMENT_BODY" == *"@claude"* ]]; then
+              echo "::notice::@claude mention is not a review request; the agent is disabled in this repo."
+              gh issue comment "$PR_NUMBER" --repo "$REPO" \
+                --body ":sleeping: The \`@claude\` agent is switched off in this repo (see #282), so it will not act on this comment. The one thing it still does is review a PR on request -- comment \`@claude review\` or \`/review\` to get one." \
+                || echo "::warning::Could not reply to the @claude mention."
+            else
+              echo "Comment is neither a '/review' command nor an '@claude review' request; skipping dispatch."
+            fi
             exit 0
           fi
           # This workflow's filename, so the dispatch resolves whatever you
@@ -91,7 +182,7 @@ jobs:
           PR_JSON=$(gh api "repos/$REPO/pulls/$PR_NUMBER")
           PR_BRANCH=$(jq -r '.head.ref' <<< "$PR_JSON")
           PR_HEAD_REPO=$(jq -r '.head.repo.full_name' <<< "$PR_JSON")
-          echo "Dispatching $WF_FILE to review PR #$PR_NUMBER ($PR_BRANCH) (/review comment)."
+          echo "Dispatching $WF_FILE to review PR #$PR_NUMBER ($PR_BRANCH) ('$TRIGGER' comment)."
           # A fork PR's head branch only exists in the fork, not in $REPO, so
           # --ref would fail to resolve there. Fall back to no --ref for fork
           # PRs; the resulting check-run mis-attributes to the default branch
@@ -105,8 +196,8 @@ jobs:
           # no git remote to infer it from.
           gh workflow run "$WF_FILE" --repo "$REPO" "${REF_ARGS[@]}" -f pr_number="$PR_NUMBER"
           gh issue comment "$PR_NUMBER" --repo "$REPO" \
-            --body ":mag: \`/review\` received -- dispatched a Claude review of this PR (see the [dispatch run]($RUN_URL)). The review posts as its own comment when it finishes." \
-            || echo "::warning::Could not acknowledge the /review comment."
+            --body ":mag: \`$TRIGGER\` received -- dispatched a Claude review of this PR (see the [dispatch run]($RUN_URL)). The review posts as its own comment when it finishes." \
+            || echo "::warning::Could not acknowledge the review request."
 
   review:
     # workflow_dispatch only while the pull_request trigger is off; the

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -6,8 +6,8 @@
 #
 # ---------------------------------------------------------------------------
 # DISABLED. The @claude agent is switched off in this repo for now; only
-# reviews are allowed, and only on request (comment `/review` on a PR -- see
-# claude-code-review.yml).
+# reviews are allowed, and only on request (comment `@claude review` or
+# `/review` on a PR -- see claude-code-review.yml).
 #
 # Two mechanisms, because either alone is insufficient:
 #   - The reactive triggers below are commented out, so no comment, issue, or
@@ -18,8 +18,17 @@
 #     manual dispatch already requires Actions write access). Without this,
 #     the placeholder trigger would leave the agent manually runnable.
 #
-# To re-enable: uncomment the trigger block below and delete the job's
-# `if: false`. Nothing else needs to change.
+# To re-enable: uncomment the trigger block below, delete the job's
+# `if: false`, and -- this part is NOT optional -- delete the `@claude review`
+# mention path from claude-code-review.yml's dispatch-on-comment job, leaving
+# it `/review`-only again.
+#
+# That mention path exists only because this workflow is off (#285: with the
+# agent disabled and dispatch gated on `/review` alone, every `@claude review`
+# went silently unanswered). Re-enabling the agent without removing it gives
+# `@claude review` two dispatchers -- the reusable workflow's own matcher and
+# that local job -- which is #277: two paid review runs per request, against
+# possibly different heads, since neither waits for the other.
 # ---------------------------------------------------------------------------
 name: Claude Code
 
@@ -59,5 +68,8 @@ jobs:
 # dispatched two paid review runs, which could review different heads since
 # the local job had no `needs: claude`. See #277 for both halves. Dispatch
 # now happens only in the reusable workflow, which applies its own
-# trusted-author gate -- and while this workflow is disabled, only via the
-# `/review` comment path in claude-code-review.yml.
+# trusted-author gate -- and while this workflow is disabled, only via
+# claude-code-review.yml's own comment path. Note that path now matches the
+# `@claude review` mention as well as `/review`, so the collision described
+# above is live again the moment this workflow is switched back on. See the
+# re-enable instructions in the header.

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: serodynamics
 Title: Modeling Longitudinal Antibody Responses to Infection
-Version: 0.1.0.9013
+Version: 0.1.0.9014
 Authors@R: c(
     person("Peter", "Teunis", , "p.teunis@emory.edu", role = c("aut", "cph"),
            comment = c("Author of the method and original code.",

--- a/NEWS.md
+++ b/NEWS.md
@@ -2,6 +2,27 @@
 
 ## Internal
 
+* Restored `@claude review` as a way to request a review (#285).
+  Disabling the agent bot moved review dispatch into
+  `claude-code-review.yml` behind a comment starting with `/review`, on the
+  reasoning that the mention form belonged to `claude.yml` -- which had just
+  been switched off.
+  So `@claude review` stopped doing anything at all, and did so silently:
+  both jobs skipped, nothing went red, and the person asking got no reply.
+  All three review requests made in the twelve days that followed used the
+  mention form and were ignored; `/review` was never typed once.
+  Both spellings now work.
+  The mention is matched with `Morrison-Lab/gha`'s own
+  `detect-review-request` action rather than a pattern of our own, so an
+  agent task
+  (`@claude, please fix the failing test`) is still not mistaken for a review
+  request, and a mention quoted in a code span or a quoted line does not
+  trigger one.
+* Replaced the silence with a reply when the `@claude` agent is addressed.
+  A mention that is not a review request now gets a short comment saying the
+  agent is switched off and naming the triggers that do work, since a skipped
+  workflow is indistinguishable from a broken bot -- which is why the gap
+  above went unnoticed for so long.
 * Disabled the `@claude` agent bot.
   `.github/workflows/claude.yml`'s reactive triggers are commented out and its
   job carries `if: false`, so no comment, issue, or review event invokes the


### PR DESCRIPTION
Fixes the skipped run at
https://github.com/UCD-SERG/serodynamics/actions/runs/31573442943.
Closes #285.

## What was wrong

`@claude review` has done nothing since #282. That PR disabled the agent and
moved review dispatch into `claude-code-review.yml` behind a comment
*starting with* `/review`, on the reasoning that the mention form belonged to
`claude.yml` -- which it had just switched off. So the mention stopped
dispatching anything.

It stopped *silently*, which is why it lasted. `dispatch-on-comment`'s gate
rejected the body, the `review` job skips every `issue_comment` run, and a run
whose jobs all skip reports `skipped` rather than failing. Nothing red, no
reply, nothing to notice.

Every review request in the twelve days since used the mention form and was
ignored. `/review` was never typed once:

| When | Who | Comment | Run |
| --- | --- | --- | --- |
| 2026-07-31T17:53Z | @sschildhauer | `@claude, review` | [30652966747](https://github.com/UCD-SERG/serodynamics/actions/runs/30652966747) |
| 2026-08-11T18:21Z | @Kwan-Jenny | `@claude review` | [31522300736](https://github.com/UCD-SERG/serodynamics/actions/runs/31522300736) |
| 2026-08-12T07:18Z | @d-morrison | `@claude review` | [31573442943](https://github.com/UCD-SERG/serodynamics/actions/runs/31573442943) |

Upstream's stub is `/review`-only because "any `@claude` also wakes
claude.yml" -- a collision that does not exist here, because claude.yml is off.
The constraint that motivated excluding the mention is absent, and excluding it
is what produced the silence.

## What changed

`dispatch-on-comment` accepts either spelling. The job-level `if:` widens to
any `@claude` mention as a pre-filter -- a GitHub Actions expression cannot
tell a review request from an agent task -- and the steps decide:

- **`detect-review-request@v2`** classifies the mention. Using gha's canonical
  matcher rather than a pattern of our own keeps the accepted phrasings and the
  code-span/blockquote stripping in one place.
- **A mention that is not a review request now gets a reply** saying the agent
  is off and naming the triggers that work, gated on **`detect-bot-mention@v2`**
  so a mention quoted in prose stays quiet. A skipped workflow is
  indistinguishable from a broken bot; that is the failure this PR is really
  about, and the mention path alone would leave it in place for
  `@claude, please fix X`.

Both matchers are `continue-on-error` and degrade in their own safe direction:
an unclassified mention still reaches the `/review` path, and an unclassified
reply is sent rather than withheld.

Bot-authored comments are excluded at the gate. The `author_association`
allowlist already covers them, but this job now quotes `@claude review` back
into the thread, so a hole in that allowlist would be a comment loop rather
than a stray run. Two independent guards, because the failure is expensive.

`claude.yml`'s re-enable instructions said "nothing else needs to change".
That is no longer true, and the header now says so: re-enabling the agent while
this mention path exists gives `@claude review` two dispatchers and reproduces
#277. Removing the mention path is now step three of re-enabling.

## Verification

No R code changed, so the R suite is not implicated; what needed testing was
the matcher and the branching, both exercised offline.

**The matcher**, run at `v2` against this repo's real comment bodies -- 10
cases, all correct. `@claude review`, `@claude, review` and
`@claude, please review` match; `@claude, please address the above issues ...`,
`@copilot, please review this PR`, a mention inside prose, one in a code span
and one in a blockquote do not.

One caveat worth recording: the matcher's stripper uses an awk interval
expression that **mawk cannot compile**, and on mawk it returns `false` for
every input with exit 0 -- a silent fail-closed. This job pins
`runs-on: ubuntu-latest`, which supplies gawk, so it is not a problem here.
Tracked upstream as [Morrison-Lab/gha#448](https://github.com/Morrison-Lab/gha/issues/448),
filed independently earlier today; this PR makes serodynamics a second
consumer of the affected matcher.

**The branching**, extracted from the `run:` block and driven with a stubbed
`gh` -- 11 cases covering both trigger spellings, `/reviewer` (must not fire),
an agent task, a prose mention, an ordinary comment, and both matchers
degraded. All pass.

That table was mutation-tested rather than assumed: deleting the mention branch
flips exactly the three mention cases from `dispatch` to `reply` and leaves the
other eight unchanged. The first mutation attempt was a silent no-op (the
extracted block scalar is dedented, so the anchor missed), which is why the
second run asserts the file actually changed before scoring the result.

**Diff-scoped checks**, run after committing against `origin/main...HEAD`:
0 banned glyphs in 155 added lines examined, and `check-new-line-breaks`
reports no lines missing semantic breaks.

`DESCRIPTION` is bumped to `0.1.0.9014` for `version-check`, and `NEWS.md` has
an entry. Two words were reworded out of the NEWS entry (`regex`,
`blockquote`) rather than added to `inst/WORDLIST`.

### Corrections to this body

- An earlier revision cited the mawk defect as `Morrison-Lab/gha#450`. That
  number was predicted before the issue was looked up and never existed; the
  dupe check then found the defect already tracked as
  [#448](https://github.com/Morrison-Lab/gha/issues/448). Corrected above.

## How to confirm after merge

Comment `@claude review` on any open PR. It should now acknowledge and dispatch
rather than skipping. The path needs this file on the default branch first, so
it cannot be tested from this PR's own branch.


---
_Generated by [Claude Code](https://claude.ai/code/session_01Kt6252bg9mCh6onaBQ58hY)_