### PR TITLE
ci: accept an `@claude review` mention alongside `/review`

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -52,18 +52,24 @@ jobs:
   # `gh workflow run` (the reusable workflow's jobs skip a raw issue_comment
   # run), so it needs this file on the default branch first.
   #
-  # Both clauses below are cheap PRE-FILTERS only, kept broad on purpose: the
-  # authoritative match happens in the steps below, where a real matcher can
-  # see Markdown and word boundaries. Keeping the gate here loose and the
-  # decision there is what lets one matcher serve both this workflow and
-  # claude.yml.
+  # The clauses below are cheap PRE-FILTERS only: the authoritative match
+  # happens in the steps, where a real matcher can see Markdown and word
+  # boundaries. Keeping the gate loose and the decision there is what lets one
+  # matcher serve both this workflow and claude.yml.
+  #
+  # The mention pre-filter requires the word `review` as well as the mention.
+  # That cannot drop a request the matcher would have accepted -- its pattern
+  # ends in `(re-?)?review`, so every body it matches contains `review`
+  # literally -- and it keeps a runner from starting for the commonest kind of
+  # mention by far, a task for the agent that never asks for a review.
   dispatch-on-comment:
     if: >-
       github.event_name == 'issue_comment' &&
       github.event.issue.pull_request &&
       contains(fromJSON('["OWNER","MEMBER","COLLABORATOR"]'), github.event.comment.author_association) &&
       (startsWith(github.event.comment.body, '/review') ||
-      contains(github.event.comment.body, '@claude'))
+      (contains(github.event.comment.body, '@claude') &&
+      contains(github.event.comment.body, 'review')))
     runs-on: ubuntu-latest
     permissions:
       actions: write        # dispatch this workflow via `gh workflow run`

--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -1,11 +1,20 @@
 # On-demand Claude Code review of pull requests -- caller stub for the central
 # Morrison-Lab/gha reusable workflow.
 #
-# Reviews run ONLY on request: comment `/review` on a PR. Automatic review on
-# PR activity is disabled (see #266), and so is the @claude agent
-# (claude.yml), so this `/review` comment path is the only way a review runs.
-# It is a slash command rather than an `@claude ...` mention on purpose: the
-# mention path lives in claude.yml, which is switched off.
+# Reviews run ONLY on request. Two comment triggers are accepted, both by the
+# dispatch-on-comment job below:
+#   * `/review` at the start of a comment, and
+#   * an `@claude review` mention.
+# Automatic review on PR activity is disabled (see #266), and so is the
+# @claude agent (claude.yml), so these two comment paths are the only ways a
+# review runs.
+#
+# The mention form is accepted HERE only because claude.yml is switched off.
+# Normally an `@claude` mention wakes that workflow, which routes a review
+# request to this one; answering it in both places dispatches two paid reviews
+# for a single comment, against possibly different heads (see #277). So if the
+# agent is ever re-enabled, the `@claude` clause in dispatch-on-comment's `if:`
+# and the mention-matcher step must be deleted at the same time.
 #
 # The workflow_dispatch path is what dispatch-on-comment re-enters, and is
 # also how claude.yml re-dispatches a review after an @claude run pushes
@@ -37,22 +46,46 @@ on:
         type: string
 
 jobs:
-  # `/review` at the start of a PR comment (from an OWNER/MEMBER/COLLABORATOR)
-  # dispatches an on-demand review of that PR. This re-enters the
-  # workflow_dispatch path below via `gh workflow run` (the reusable
-  # workflow's jobs skip a raw issue_comment run), so it needs this file on
-  # the default branch first.
+  # `/review` at the start of a PR comment, or an `@claude review` mention in
+  # one (from an OWNER/MEMBER/COLLABORATOR), dispatches an on-demand review of
+  # that PR. This re-enters the workflow_dispatch path below via
+  # `gh workflow run` (the reusable workflow's jobs skip a raw issue_comment
+  # run), so it needs this file on the default branch first.
+  #
+  # Both clauses below are cheap PRE-FILTERS only, kept broad on purpose: the
+  # authoritative match happens in the steps below, where a real matcher can
+  # see Markdown and word boundaries. Keeping the gate here loose and the
+  # decision there is what lets one matcher serve both this workflow and
+  # claude.yml.
   dispatch-on-comment:
     if: >-
       github.event_name == 'issue_comment' &&
       github.event.issue.pull_request &&
-      startsWith(github.event.comment.body, '/review') &&
-      contains(fromJSON('["OWNER","MEMBER","COLLABORATOR"]'), github.event.comment.author_association)
+      contains(fromJSON('["OWNER","MEMBER","COLLABORATOR"]'), github.event.comment.author_association) &&
+      (startsWith(github.event.comment.body, '/review') ||
+      contains(github.event.comment.body, '@claude'))
     runs-on: ubuntu-latest
     permissions:
       actions: write        # dispatch this workflow via `gh workflow run`
-      issues: write         # acknowledge the /review comment
+      issues: write         # acknowledge the triggering comment
     steps:
+      # Decides whether an `@claude` mention is actually a review REQUEST, as
+      # opposed to a task for the agent, a question, or the word quoted while
+      # writing about it. Reuses the matcher claude.yml itself uses rather
+      # than a second inline pattern, so this path inherits its code-span and
+      # fenced-block stripping and its accepted-phrasing set, and cannot drift
+      # away from them (the two-copies drift that caused #277).
+      #
+      # Skipped on the `/review` path, which needs no mention matching; the
+      # step's output is then the empty string, which the shell below treats
+      # as "no mention match".
+      - name: Check whether the comment is an `@claude review` request
+        id: mention
+        if: ${{ !startsWith(github.event.comment.body, '/review') }}
+        uses: Morrison-Lab/gha/.github/actions/detect-review-request@v2
+        with:
+          comment-body: ${{ github.event.comment.body }}
+
       - name: Parse this workflow's ref
         id: this-wf
         uses: Morrison-Lab/gha/.github/actions/parse-workflow-ref@v2
@@ -68,16 +101,28 @@ jobs:
           # Passed via env (not inlined) so the comment body is a shell value,
           # never interpreted as script -- avoids injection.
           COMMENT_BODY: ${{ github.event.comment.body }}
+          # 'true' when the matcher step above ran and matched. Empty when it
+          # was skipped, i.e. on the `/review` path.
+          MENTION_MATCH: ${{ steps.mention.outputs.match }}
           RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
         run: |
           set -euo pipefail
-          # The job-level `if:` only does a cheap startsWith('/review')
-          # pre-filter; GitHub Actions expressions can't reliably tell
-          # '/review' from '/reviewer' or handle a newline/tab after the
-          # command. Enforce the real match here: the body must begin with a
-          # standalone '/review' token, followed by whitespace or end-of-string.
-          if [[ ! "$COMMENT_BODY" =~ ^/review([[:space:]]|$) ]]; then
-            echo "Comment does not start with a standalone '/review' command; skipping dispatch."
+          # The job-level `if:` only does cheap pre-filters. GitHub Actions
+          # expressions can't reliably tell '/review' from '/reviewer' or
+          # handle a newline/tab after the command, and contains(body,
+          # '@claude') matches a mention anywhere in the body -- including one
+          # quoted in a code span or a blockquote, which must NOT dispatch.
+          # Enforce the real match here: the body must either begin with a
+          # standalone '/review' token followed by whitespace or
+          # end-of-string, or be a review request per the matcher step above.
+          # `${MENTION_MATCH:-}` because that step is skipped on the /review
+          # path, and `set -u` would abort on an unset variable.
+          if [[ "$COMMENT_BODY" =~ ^/review([[:space:]]|$) ]]; then
+            TRIGGER='/review'
+          elif [ "${MENTION_MATCH:-}" = 'true' ]; then
+            TRIGGER='@claude review'
+          else
+            echo "Comment is neither a standalone '/review' command nor an '@claude review' request; skipping dispatch."
             exit 0
           fi
           # This workflow's filename, so the dispatch resolves whatever you
@@ -91,7 +136,7 @@ jobs:
           PR_JSON=$(gh api "repos/$REPO/pulls/$PR_NUMBER")
           PR_BRANCH=$(jq -r '.head.ref' <<< "$PR_JSON")
           PR_HEAD_REPO=$(jq -r '.head.repo.full_name' <<< "$PR_JSON")
-          echo "Dispatching $WF_FILE to review PR #$PR_NUMBER ($PR_BRANCH) (/review comment)."
+          echo "Dispatching $WF_FILE to review PR #$PR_NUMBER ($PR_BRANCH) ($TRIGGER comment)."
           # A fork PR's head branch only exists in the fork, not in $REPO, so
           # --ref would fail to resolve there. Fall back to no --ref for fork
           # PRs; the resulting check-run mis-attributes to the default branch
@@ -104,9 +149,16 @@ jobs:
           # --repo is required: this job doesn't check out the repo, so gh has
           # no git remote to infer it from.
           gh workflow run "$WF_FILE" --repo "$REPO" "${REF_ARGS[@]}" -f pr_number="$PR_NUMBER"
+          # $TRIGGER is wrapped in a code span here for two reasons: it reads
+          # better, and on the mention path it keeps this acknowledgement from
+          # being read as a review request itself. Two independent things stop
+          # that loop -- GitHub does not raise events for comments posted with
+          # GITHUB_TOKEN, and the matcher strips code spans before matching --
+          # and the code span is the half that stays true if the token ever
+          # changes.
           gh issue comment "$PR_NUMBER" --repo "$REPO" \
-            --body ":mag: \`/review\` received -- dispatched a Claude review of this PR (see the [dispatch run]($RUN_URL)). The review posts as its own comment when it finishes." \
-            || echo "::warning::Could not acknowledge the /review comment."
+            --body ":mag: \`$TRIGGER\` received -- dispatched a Claude review of this PR (see the [dispatch run]($RUN_URL)). The review posts as its own comment when it finishes." \
+            || echo "::warning::Could not acknowledge the $TRIGGER comment."
 
   review:
     # workflow_dispatch only while the pull_request trigger is off; the

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -6,8 +6,8 @@
 #
 # ---------------------------------------------------------------------------
 # DISABLED. The @claude agent is switched off in this repo for now; only
-# reviews are allowed, and only on request (comment `/review` on a PR -- see
-# claude-code-review.yml).
+# reviews are allowed, and only on request (comment `/review` on a PR, or
+# mention `@claude review` -- see claude-code-review.yml).
 #
 # Two mechanisms, because either alone is insufficient:
 #   - The reactive triggers below are commented out, so no comment, issue, or
@@ -19,7 +19,11 @@
 #     the placeholder trigger would leave the agent manually runnable.
 #
 # To re-enable: uncomment the trigger block below and delete the job's
-# `if: false`. Nothing else needs to change.
+# `if: false` -- AND, in the same change, delete the `@claude` clause in
+# claude-code-review.yml's dispatch-on-comment `if:` together with its
+# mention-matcher step. That job accepts the mention only because this
+# workflow is off; leaving both in place makes a single `@claude review`
+# comment dispatch two paid reviews, against possibly different heads (#277).
 # ---------------------------------------------------------------------------
 name: Claude Code
 
@@ -59,5 +63,6 @@ jobs:
 # dispatched two paid review runs, which could review different heads since
 # the local job had no `needs: claude`. See #277 for both halves. Dispatch
 # now happens only in the reusable workflow, which applies its own
-# trusted-author gate -- and while this workflow is disabled, only via the
-# `/review` comment path in claude-code-review.yml.
+# trusted-author gate -- and while this workflow is disabled, only via
+# claude-code-review.yml's dispatch-on-comment job, which accepts `/review`
+# and, precisely because this workflow is off, an `@claude review` mention.

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: serodynamics
 Title: Modeling Longitudinal Antibody Responses to Infection
-Version: 0.1.0.9013
+Version: 0.1.0.9014
 Authors@R: c(
     person("Peter", "Teunis", , "p.teunis@emory.edu", role = c("aut", "cph"),
            comment = c("Author of the method and original code.",

--- a/NEWS.md
+++ b/NEWS.md
@@ -2,13 +2,29 @@
 
 ## Internal
 
+* Accepted an `@claude review` mention as a review trigger, alongside
+  `/review`.
+  Disabling the agent bot left `/review` as the only phrasing that dispatched
+  a review, but the mention is what everyone kept typing, and it produced a
+  run with every job skipped and no comment posted -- indistinguishable from a
+  broken bot.
+  Three review requests from members went unanswered that way.
+  `claude-code-review.yml`'s `dispatch-on-comment` job now also accepts the
+  mention, matched with `Morrison-Lab/gha`'s own `detect-review-request`
+  action rather than a second hand-rolled pattern, so a mention that is a task
+  for the agent, a question, or the phrasing merely quoted in a code span or
+  blockquote still does not dispatch.
+  The mention is accepted only while the agent is off; `claude.yml`'s
+  re-enable instructions now say to remove it at the same time, since
+  answering one comment in both workflows dispatches two paid reviews.
 * Disabled the `@claude` agent bot.
   `.github/workflows/claude.yml`'s reactive triggers are commented out and its
   job carries `if: false`, so no comment, issue, or review event invokes the
   agent, and neither does a manual dispatch (the reusable workflow runs
   unattended on `workflow_dispatch` by design).
   Reviews are the only Claude capability left, and they run on request only:
-  comment `/review` on a pull request.
+  comment `/review` on a pull request (an `@claude review` mention was added
+  as a second trigger afterwards -- see the entry above).
   That path is new here -- `claude-code-review.yml` gained an `issue_comment`
   trigger and a `dispatch-on-comment` job, since the `@claude review` mention
   it previously relied on went away with the agent.

--- a/inst/WORDLIST
+++ b/inst/WORDLIST
@@ -29,6 +29,7 @@ assignees
 behaviour
 biomarker
 biomarkers
+blockquote
 calc
 colour
 colours


### PR DESCRIPTION
Closes #285.

Also resolves `Morrison-Lab/gha#450`, the same bug filed in the `gha` repo
because the session that wrote it could not reach this one. The fix belongs
here: `examples/` in `gha` is copy-and-edit, so landing the upstream variant
(`Morrison-Lab/gha#449`) would not change this repo.

## Problem

Disabling the agent (#282) left `/review` as the only phrasing that dispatched
a review. The mention is what people actually type, and it produced a run with
every job skipped and no comment posted, which is indistinguishable from a
broken bot. Three review requests from members went unanswered that way
(#285 has the table).

## Change

`dispatch-on-comment` now accepts either form. The job-level `if:` stays a
cheap pre-filter and the authoritative decision moves into the steps, where a
real matcher can see Markdown and word boundaries:

- `/review` at the start of a comment, as before, or
- a mention that `Morrison-Lab/gha`'s own `detect-review-request@v2` action
  classifies as a review request.

Reusing that action rather than writing a second inline pattern is the point:
this path inherits its code-span and fenced-block stripping and its
accepted-phrasing set, and cannot drift away from them the way two copies of
the pattern did in #277.

The mention is accepted **only because `claude.yml` is off**. `claude.yml`'s
re-enable instructions now say to delete this path in the same change, since
answering one comment in both workflows dispatches two paid reviews against
possibly different heads.

## Verification

I ran the real matcher (extracted from `gha` at the `v2` tag) against 26 cases,
20 of them **real comment bodies taken from this repo's own PR #230**, through
a simulation of the full gate (job `if:` -> matcher step -> shell `TRIGGER`
logic). 26 examined, 0 failures.

| comment | before | after |
| --- | --- | --- |
| `/review`, `/review please` | dispatches | dispatches |
| `/reviewer` | no dispatch | no dispatch |
| the 3 real member review requests that got silence | **silence** | **dispatches** |
| real agent tasks (`@claude, please update this PR ...`) | no dispatch | no dispatch |
| the `@claude` mention quoted in a code span, in a real bot comment | no dispatch | no dispatch |
| a real **blockquoted** `@claude, please review` (quote-reply) | no dispatch | no dispatch |
| a mention asking a question | no dispatch | no dispatch |
| non-member comment, either form | job skipped | job skipped |

Two loop checks, since the mention path is new:

- The acknowledgement this job posts contains `` `@claude review` `` in a code
  span. Fed back through the matcher it returns `false`, so it cannot
  re-trigger itself even setting aside that GitHub raises no events for
  comments posted with `GITHUB_TOKEN`. Both are noted in the code.
- `@claude reviewer` still does not match.

Both workflow files parse as YAML. No banned punctuation in 107 added lines,
and `check-new-line-breaks` reports no missing semantic breaks.

## What this PR cannot verify before merge

- **The `issue_comment` path itself.** GitHub runs the **default branch's**
  copy of a workflow for `issue_comment` events, so commenting on this PR
  exercises `main`'s version, not this one. The file's own comment already
  notes it "needs this file on the default branch first." Verified by
  simulation instead, above.
- **A Claude review of this PR.** The diff edits
  `.github/workflows/claude-code-review.yml`, which trips the reusable
  workflow's self-modification guard (`v2`, lines 391-406): it sets
  `self_mod=true` and skips every review step, because the action's OIDC
  workflow-validation 401s until the file matches the default branch. So
  `review / require-review` will show a **gray skip, not an all-clear** --
  please do not read it as one. Copilot is requested as the external reviewer,
  and a self-review is posted below.

## Out of scope

- `docs-check` is already failing on `main`: it failed on this PR's empty
  scaffold commit, whose tree is byte-identical to `main`'s
  (`1a34593bad0b4b43d1cbab39d2edad3ae9520a59`). `devtools::document()` dirties
  `DESCRIPTION` and `NAMESPACE` there. Not caused by this change; filed
  separately.
- Replying to a trusted `@claude` mention that is *not* a review request, so
  "the agent is off" is visible rather than inferred, is the second half of
  #285. Deferred and filed separately rather than folded in here: which
  mentions deserve an automated reply is a judgment call worth its own
  review, and a reply on every prose mention would be noise.
