### PR TITLE
docs: regenerate NAMESPACE and DESCRIPTION under roxygen2 8.1.0

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: serodynamics
 Title: Modeling Longitudinal Antibody Responses to Infection
-Version: 0.1.0.9014
+Version: 0.1.0.9015
 Authors@R: c(
     person("Peter", "Teunis", , "p.teunis@emory.edu", role = c("aut", "cph"),
            comment = c("Author of the method and original code.",
@@ -78,5 +78,4 @@ Depends:
     R (>= 4.1.0)
 LazyData: true
 VignetteBuilder: knitr, quarto
-Config/roxygen2/version: 8.0.0
-RoxygenNote: 8.0.0
+Config/roxygen2/version: 8.1.0

--- a/NAMESPACE
+++ b/NAMESPACE
@@ -23,30 +23,40 @@ export(serodynamics_example)
 export(sim_case_data)
 export(sim_n_obs)
 export(summarize_posterior)
-importFrom(dplyr,.data)
-importFrom(dplyr,all_of)
-importFrom(dplyr,filter)
-importFrom(dplyr,mutate)
-importFrom(dplyr,n)
-importFrom(dplyr,reframe)
-importFrom(dplyr,rename)
-importFrom(dplyr,rowwise)
-importFrom(dplyr,select)
-importFrom(dplyr,ungroup)
+importFrom(dplyr,
+  .data,
+  all_of,
+  filter,
+  mutate,
+  n,
+  reframe,
+  rename,
+  rowwise,
+  select,
+  ungroup
+)
 importFrom(ggmcmc,ggs)
-importFrom(ggplot2,autoplot)
-importFrom(ggplot2,theme_bw)
-importFrom(ggplot2,vars)
-importFrom(rlang,.data)
-importFrom(rlang,.env)
+importFrom(ggplot2,
+  autoplot,
+  theme_bw,
+  vars
+)
+importFrom(rlang,
+  .data,
+  .env
+)
 importFrom(runjags,run.jags)
-importFrom(serocalculator,get_biomarker_levels)
-importFrom(serocalculator,get_biomarker_names)
-importFrom(serocalculator,get_biomarker_names_var)
-importFrom(serocalculator,get_values)
-importFrom(serocalculator,ids)
-importFrom(serocalculator,ids_varname)
-importFrom(stats,complete.cases)
-importFrom(stats,quantile)
+importFrom(serocalculator,
+  get_biomarker_levels,
+  get_biomarker_names,
+  get_biomarker_names_var,
+  get_values,
+  ids,
+  ids_varname
+)
+importFrom(stats,
+  complete.cases,
+  quantile
+)
 importFrom(tidyr,pivot_wider)
 importFrom(utils,read.csv)

--- a/NEWS.md
+++ b/NEWS.md
@@ -2,6 +2,21 @@
 
 ## Internal
 
+* Regenerated `NAMESPACE` and `DESCRIPTION` under roxygen2 8.1.0 (#288).
+  The documentation check installs whatever roxygen2 is current rather than a
+  fixed version, so the 8.1.0 release started rewriting both files against the
+  8.0.0 they were generated with, and the check failed on every pull request
+  -- including ones that touch no R code at all.
+  The `NAMESPACE` change is formatting only: where several symbols come from
+  one package, 8.1.0 groups them into a single `importFrom()` call instead of
+  writing a line for each.
+  Parsing both versions gives the same 22 exports, 27 imports and one S3
+  method.
+  `DESCRIPTION` moves to `Config/roxygen2/version: 8.1.0` and drops the older
+  `RoxygenNote` field, which 8.1.0 no longer writes.
+  The version is left floating rather than fixed, so a later roxygen2 release
+  will need the same treatment.
+
 * Restored `@claude review` as a way to request a review (#285).
   Disabling the agent bot moved review dispatch into
   `claude-code-review.yml` behind a comment starting with `/review`, on the


### PR DESCRIPTION
Closes #288. Unblocks `docs-check` on every open PR.

## What was wrong

`docs-check` installs `any::roxygen2`, so it runs whatever is current. That is
now **8.1.0**, and the committed files were generated with 8.0.0 -- so
`roxygenise()` rewrites both, and the check's "no diff after documenting"
assertion fails.

It failed on every PR, including ones with no R code: #283 (a submodule bump)
and #286 (workflow YAML) both failed identically, and #286's base commit
8b53be4 had been green on `main` twelve days earlier. Nothing in the repository
changed; roxygen2 released.

It also explains the report on #230 from 2026-08-05 -- *"document() does not
show any changes in the local environment"*. A contributor on 8.0.0 genuinely
sees no diff; the drift exists only against CI's newer copy.

## The change

- **`NAMESPACE`** -- formatting only. Where several symbols come from one
  package, 8.1.0 groups them into a single `importFrom()` call instead of a
  line each.
- **`DESCRIPTION`** -- `Config/roxygen2/version` goes to 8.1.0, and
  `RoxygenNote` is dropped, which 8.1.0 no longer writes.

Per your call on #288, the roxygen2 version **stays floating** rather than
pinned. A later release will need the same treatment; that is the accepted
trade.

## Verification

**Generated with CI's own version**, not merely a recent one: roxygen2 8.1.0,
on Ubuntu noble, installed from the same
`packagemanager.posit.co/cran/__linux__/noble/latest` binary repo the workflow
uses.

**Matching the environment turned out to matter**, and is worth recording. A
first run produced a *third* changed file, `man/expect_snapshot_data.Rd`,
because `testthat` sits in `Suggests` and was not installed, so that file's
`@inheritDotParams testthat::expect_snapshot_file` could not resolve and
roxygen emitted the topic without the inherited arguments. roxygen said so
outright rather than degrading quietly:

```
x expect_snapshot_data.R:10: @returns refers to un-installed package testthat.
x In topic 'expect_snapshot_data': @inheritDotParams failed because testthat is not installed.
```

Those warnings, plus the extra file being one CI never reports, are what
flagged the environment as wrong rather than the output. Installing the full
`Suggests` set reproduced CI's exact two-file result with no warnings.

**The NAMESPACE change is semantically inert**, established by parsing rather
than by reading the diff. `parseNamespaceFile()` on both versions gives
identical sets:

| | before | after |
| --- | --- | --- |
| exports | 22 | 22 |
| imports | 27 | 27 |
| S3 methods | 1 | 1 |

That comparator was itself checked against a deliberately dropped import
(`stats::quantile`), which it reports by name -- so "identical" is a measured
result rather than a checker that cannot fail.

**CI's assertion reproduced locally.** Re-running `roxygenise()` against the
committed tree and applying the workflow's own
`git diff-index HEAD --name-only -- man/ NAMESPACE DESCRIPTION` returns empty.

**Other checks:** `spelling::spell_check_package()` is clean (0 misspellings --
the real package, not a proxy). 0 banned glyphs in 52 added lines examined, and
`check-new-line-breaks` reports none missing. `DESCRIPTION` is bumped to
`0.1.0.9015`.

## Corrections to this body

Both found in review of the corpus entry this session wrote from the same
material ([Morrison-Lab/ai-config#1401](https://github.com/Morrison-Lab/ai-config/pull/1401)),
and corrected here so the two do not disagree. Neither affects the diff.

- An earlier revision said roxygen **silently** emitted a degraded topic. It
  did not -- it printed the two warnings quoted above, naming the tag and the
  missing package. Those warnings were in fact the first signal acted on, so
  calling the extra file "the tell" understated a better one.
- An earlier revision attributed that file's degradation to `testthat` **and**
  `rjags`. Only `testthat` is causally connected to it: `R/expect_snapshot_data.R`
  contains no `rjags` reference. `rjags` was absent too and was flagged on
  `R/run_serodynamics.R`, whose output did not change.

## Note

I did not touch renv -- this repository has no `renv.lock`, no `renv/`, and no
renv reference in any workflow. Its `.Rprofile` uses `pacman` for interactive
sessions only. Nothing to update.
